### PR TITLE
Ocsp stapling tmg otp25

### DIFF
--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -20,7 +20,7 @@
 
 %%
 
-%%% Purpose : Main API module for the SSL application that implements TLS and DTLS 
+%%% Purpose : Main API module for the SSL application that implements TLS and DTLS
 %%% SSL is a legacy name.
 
 -module(ssl).
@@ -41,71 +41,71 @@
 -endif.
 
 %% Application handling
--export([start/0, 
-         start/1, 
-         stop/0, 
+-export([start/0,
+         start/1,
+         stop/0,
          clear_pem_cache/0]).
 
 %% Socket handling
--export([connect/3, 
-         connect/2, 
+-export([connect/3,
+         connect/2,
          connect/4,
-	 listen/2, 
-         transport_accept/1, 
+	 listen/2,
+         transport_accept/1,
          transport_accept/2,
-	 handshake/1, 
-         handshake/2, 
-         handshake/3, 
+	 handshake/1,
+         handshake/2,
+         handshake/3,
          handshake_continue/2,
-         handshake_continue/3, 
+         handshake_continue/3,
          handshake_cancel/1,
-	 controlling_process/2, 
-         peername/1, 
-         peercert/1, 
+	 controlling_process/2,
+         peername/1,
+         peercert/1,
          sockname/1,
-	 close/1, 
-         close/2, 
-         shutdown/2, 
-         recv/2, 
-         recv/3, 
+	 close/1,
+         close/2,
+         shutdown/2,
+         recv/2,
+         recv/3,
          send/2,
-	 getopts/2, 
-         setopts/2, 
-         getstat/1, 
+	 getopts/2,
+         setopts/2,
+         getstat/1,
          getstat/2
 	]).
 
 %% SSL/TLS protocol handling
--export([cipher_suites/2, 
+-export([cipher_suites/2,
          cipher_suites/3,
          filter_cipher_suites/2,
-         prepend_cipher_suites/2, 
+         prepend_cipher_suites/2,
          append_cipher_suites/2,
-         eccs/0, 
-         eccs/1, 
-         versions/0, 
-         groups/0, 
+         eccs/0,
+         eccs/1,
+         versions/0,
+         groups/0,
          groups/1,
-         format_error/1, 
-         renegotiate/1, 
+         format_error/1,
+         renegotiate/1,
          update_keys/2,
-         prf/5, 
-         negotiated_protocol/1, 
-	 connection_information/1, 
+         prf/5,
+         negotiated_protocol/1,
+	 connection_information/1,
          connection_information/2]).
 %% Misc
 -export([handle_options/2,
          handle_options/3,
-         tls_version/1, 
+         tls_version/1,
          suite_to_str/1,
          suite_to_openssl_str/1,
          str_to_suite/1]).
 
--removed({ssl_accept, '_', 
+-removed({ssl_accept, '_',
           "use ssl_handshake/1,2,3 instead"}).
--removed({cipher_suites, 0, 
+-removed({cipher_suites, 0,
           "use cipher_suites/2,3 instead"}).
--removed({cipher_suites, 1, 
+-removed({cipher_suites, 1,
           "use cipher_suites/2,3 instead"}).
 -removed([{negotiated_next_protocol,1,
           "use ssl:negotiated_protocol/1 instead"}]).
@@ -117,17 +117,17 @@
               socket_option/0,
               active_msgs/0,
               host/0,
-              tls_option/0,              
+              tls_option/0,
               tls_client_option/0,
-              tls_server_option/0,                            
+              tls_server_option/0,
               erl_cipher_suite/0,
               old_cipher_suite/0,
-              ciphers/0,             
+              ciphers/0,
               cipher/0,
               hash/0,
               key/0,
               kex_algo/0,
-              prf_random/0, 
+              prf_random/0,
               cipher_filters/0,
               sign_algo/0,
               protocol_version/0,
@@ -151,7 +151,7 @@
 -type active_msgs()              :: {ssl, sslsocket(), Data::binary() | list()} | {ssl_closed, sslsocket()} |
                                     {ssl_error, sslsocket(), Reason::any()} | {ssl_passive, sslsocket()}. % exported
 -type transport_option()         :: {cb_info, {CallbackModule::atom(), DataTag::atom(),
-                                               ClosedTag::atom(), ErrTag::atom()}} |  
+                                               ClosedTag::atom(), ErrTag::atom()}} |
                                     {cb_info, {CallbackModule::atom(), DataTag::atom(),
                                                ClosedTag::atom(), ErrTag::atom(), PassiveTag::atom()}}.
 -type host()                     :: hostname() | ip_address(). % exported
@@ -171,7 +171,7 @@
                                     aes_128_ccm |
                                     aes_256_ccm |
                                     aes_128_ccm_8 |
-                                    aes_256_ccm_8 |                                    
+                                    aes_256_ccm_8 |
                                     chacha20_poly1305 |
                                     legacy_cipher(). % exported
 -type legacy_cipher()            ::  rc4_128 |
@@ -226,11 +226,11 @@
                                     cipher := cipher(),
                                     mac    := hash() | aead,
                                     prf    := hash() | default_prf %% Old cipher suites, version dependent
-                                   }.  
+                                   }.
 
--type old_cipher_suite() :: {kex_algo(), cipher(), hash()} % Pre TLS 1.2 
+-type old_cipher_suite() :: {kex_algo(), cipher(), hash()} % Pre TLS 1.2
                              %% TLS 1.2, internally PRE TLS 1.2 will use default_prf
-                           | {kex_algo(), cipher(), hash() | aead, hash()}. 
+                           | {kex_algo(), cipher(), hash() | aead, hash()}.
 
 -type named_curve()           :: sect571r1 |
                                  sect571k1 |
@@ -274,22 +274,22 @@
 
 -type error_alert()           :: {tls_alert, {tls_alert(), Description::string()}}. % exported
 
--type tls_alert()             :: close_notify | 
-                                 unexpected_message | 
-                                 bad_record_mac | 
-                                 record_overflow | 
+-type tls_alert()             :: close_notify |
+                                 unexpected_message |
+                                 bad_record_mac |
+                                 record_overflow |
                                  handshake_failure |
-                                 bad_certificate | 
-                                 unsupported_certificate | 
-                                 certificate_revoked | 
-                                 certificate_expired | 
+                                 bad_certificate |
+                                 unsupported_certificate |
+                                 certificate_revoked |
+                                 certificate_expired |
                                  certificate_unknown |
-                                 illegal_parameter | 
-                                 unknown_ca | 
-                                 access_denied | 
-                                 decode_error | 
-                                 decrypt_error | 
-                                 export_restriction| 
+                                 illegal_parameter |
+                                 unknown_ca |
+                                 access_denied |
+                                 decode_error |
+                                 decrypt_error |
+                                 export_restriction|
                                  protocol_version |
                                  insufficient_security |
                                  internal_error |
@@ -344,11 +344,11 @@
 -type handshake_completion()      :: hello | full.
 -type cert()                      :: public_key:der_encoded().
 -type cert_pem()                  :: file:filename().
--type key()                       :: {'RSAPrivateKey'| 'DSAPrivateKey' | 'ECPrivateKey' |'PrivateKeyInfo', 
-                                           public_key:der_encoded()} | 
-                                     #{algorithm := rsa | dss | ecdsa, 
-                                       engine := crypto:engine_ref(), 
-                                       key_id := crypto:key_id(), 
+-type key()                       :: {'RSAPrivateKey'| 'DSAPrivateKey' | 'ECPrivateKey' |'PrivateKeyInfo',
+                                           public_key:der_encoded()} |
+                                     #{algorithm := rsa | dss | ecdsa,
+                                       engine := crypto:engine_ref(),
+                                       key_id := crypto:key_id(),
                                        password => crypto:password()}. % exported
 -type key_pem()                   :: file:filename().
 -type key_pem_password()          :: iodata() | fun(() -> iodata()).
@@ -365,7 +365,7 @@
                                         algo_filter()}). % exported
 -type algo_filter()               :: fun((kex_algo()|cipher()|hash()|aead|default_prf) -> true | false).
 -type keep_secrets()              :: boolean().
--type secure_renegotiation()      :: boolean(). 
+-type secure_renegotiation()      :: boolean().
 -type allowed_cert_chain_length() :: integer().
 
 -type custom_verify()               ::  {Verifyfun :: fun(), InitialUserState :: any()}.
@@ -380,7 +380,7 @@
 -type signature_algs()           ::  [{hash(), sign_algo()} | sign_scheme()].
 -type supported_groups()         ::  [group()].
 -type custom_user_lookup()       ::  {Lookupfun :: fun(), UserState :: any()}.
--type padding_check()            :: boolean(). 
+-type padding_check()            :: boolean().
 -type beast_mitigation()         :: one_n_minus_one | zero_n | disabled.
 -type srp_identity()             :: {Username :: string(), Password :: string()}.
 -type psk_identity()             :: string().
@@ -434,15 +434,15 @@
 -type client_cafile()            :: file:filename().
 -type app_level_protocol()       :: binary().
 -type client_alpn()              :: [app_level_protocol()].
--type client_preferred_next_protocols() :: {Precedence :: server | client, 
+-type client_preferred_next_protocols() :: {Precedence :: server | client,
                                             ClientPrefs :: [app_level_protocol()]} |
-                                           {Precedence :: server | client, 
-                                            ClientPrefs :: [app_level_protocol()], 
+                                           {Precedence :: server | client,
+                                            ClientPrefs :: [app_level_protocol()],
                                             Default::app_level_protocol()}.
 -type client_psk_identity()             :: psk_identity().
 -type client_srp_identity()             :: srp_identity().
 -type customize_hostname_check() :: list().
--type sni()                      :: HostName :: hostname() | disable. 
+-type sni()                      :: HostName :: hostname() | disable.
 -type max_fragment_length()      :: undefined | 512 | 1024 | 2048 | 4096.
 -type fallback()                 :: boolean().
 -type ssl_imp()                  :: new | old.
@@ -588,9 +588,9 @@ connect(Socket, SslOptions) ->
       Port :: inet:port_number(),
       TLSOptions :: [tls_client_option()].
 
-connect(Socket, SslOptions0, Timeout) when is_list(SslOptions0) andalso 
+connect(Socket, SslOptions0, Timeout) when is_list(SslOptions0) andalso
                                            (is_integer(Timeout) andalso Timeout >= 0) or (Timeout == infinity) ->
-    
+
     CbInfo = handle_option_cb_info(SslOptions0, tls),
     Transport = element(1, CbInfo),
     try handle_options(Transport, Socket, SslOptions0, client, undefined) of
@@ -599,7 +599,7 @@ connect(Socket, SslOptions0, Timeout) when is_list(SslOptions0) andalso
     catch
         _:{error, Reason} ->
             {error, Reason}
-    end; 
+    end;
 connect(Host, Port, Options) ->
     connect(Host, Port, Options, infinity).
 
@@ -665,7 +665,7 @@ transport_accept(ListenSocket) ->
       SslSocket :: sslsocket().
 
 transport_accept(#sslsocket{pid = {ListenSocket,
-				   #config{connection_cb = ConnectionCb} = Config}}, Timeout) 
+				   #config{connection_cb = ConnectionCb} = Config}}, Timeout)
   when (is_integer(Timeout) andalso Timeout >= 0) or (Timeout == infinity) ->
     case ConnectionCb of
 	tls_gen_connection ->
@@ -673,7 +673,7 @@ transport_accept(#sslsocket{pid = {ListenSocket,
 	dtls_gen_connection ->
 	    dtls_socket:accept(ListenSocket, Config, Timeout)
     end.
-  
+
 %%--------------------------------------------------------------------
 %%
 %% Description: Performs accept on an ssl listen socket. e.i. performs
@@ -703,7 +703,7 @@ handshake(ListenSocket) ->
       Ext :: protocol_extensions(),
       Reason :: closed | timeout | error_alert().
 
-handshake(#sslsocket{} = Socket, Timeout) when  (is_integer(Timeout) andalso Timeout >= 0) or 
+handshake(#sslsocket{} = Socket, Timeout) when  (is_integer(Timeout) andalso Timeout >= 0) or
                                                 (Timeout == infinity) ->
     ssl_gen_statem:handshake(Socket, Timeout);
 
@@ -726,7 +726,7 @@ handshake(ListenSocket, SslOptions) ->
       Ext :: protocol_extensions(),
       Reason :: closed | timeout | {options, any()} | error_alert().
 
-handshake(#sslsocket{} = Socket, [], Timeout) when (is_integer(Timeout) andalso Timeout >= 0) or 
+handshake(#sslsocket{} = Socket, [], Timeout) when (is_integer(Timeout) andalso Timeout >= 0) or
                                                     (Timeout == infinity)->
     handshake(Socket, Timeout);
 handshake(#sslsocket{fd = {_, _, _, Trackers}} = Socket, SslOpts, Timeout) when
@@ -758,13 +758,13 @@ handshake(Socket, SslOptions, Timeout) when (is_integer(Timeout) andalso Timeout
             {ok, Port} = tls_socket:port(Transport, Socket),
             {ok, SessionIdHandle} = tls_socket:session_id_tracker(ssl_unknown_listener, SslOpts),
             ssl_gen_statem:handshake(ConnetionCb, Port, Socket,
-                                     {SslOpts, 
+                                     {SslOpts,
                                       tls_socket:emulated_socket_options(EmOpts, #socket_options{}),
                                       [{session_id_tracker, SessionIdHandle}]},
                                      self(), CbInfo, Timeout)
     catch
         Error = {error, _Reason} -> Error
-    end.   
+    end.
 
 %%--------------------------------------------------------------------
 -spec handshake_continue(HsSocket, Options) ->
@@ -839,7 +839,7 @@ close(#sslsocket{pid = [TLSPid|_]}, Timeout) when is_pid(TLSPid),
 					      (is_integer(Timeout) andalso Timeout >= 0) or (Timeout == infinity) ->
     ssl_gen_statem:close(TLSPid, {close, Timeout});
 close(#sslsocket{pid = {dtls = ListenSocket, #config{transport_info={Transport,_,_,_,_}}}}, _) ->
-    dtls_socket:close(Transport, ListenSocket);    
+    dtls_socket:close(Transport, ListenSocket);
 close(#sslsocket{pid = {ListenSocket, #config{transport_info={Transport,_,_,_,_}}}}, _) ->
     tls_socket:close(Transport, ListenSocket).
 
@@ -905,7 +905,7 @@ controlling_process(#sslsocket{pid = [Pid|_]}, NewOwner) when is_pid(Pid), is_pi
     ssl_gen_statem:new_user(Pid, NewOwner);
 controlling_process(#sslsocket{pid = {dtls, _}},
 		    NewOwner) when is_pid(NewOwner) ->
-    ok; %% Meaningless but let it be allowed to conform with TLS 
+    ok; %% Meaningless but let it be allowed to conform with TLS
 controlling_process(#sslsocket{pid = {Listen,
 				      #config{transport_info = {Transport,_,_,_,_}}}},
 		    NewOwner) when is_pid(NewOwner) ->
@@ -919,7 +919,7 @@ controlling_process(#sslsocket{pid = {Listen,
 %%
 %% Description: Return SSL information for the connection
 %%--------------------------------------------------------------------
-connection_information(#sslsocket{pid = [Pid|_]}) when is_pid(Pid) -> 
+connection_information(#sslsocket{pid = [Pid|_]}) when is_pid(Pid) ->
     case ssl_gen_statem:connection_information(Pid, false) of
 	{ok, Info} ->
 	    {ok, [Item || Item = {_Key, Value} <- Info,  Value =/= undefined]};
@@ -936,7 +936,7 @@ connection_information(#sslsocket{pid = {_Listen, #config{}}}) ->
 %%
 %% Description: Return SSL information for the connection
 %%--------------------------------------------------------------------
-connection_information(#sslsocket{pid = [Pid|_]}, Items) when is_pid(Pid) -> 
+connection_information(#sslsocket{pid = [Pid|_]}, Items) when is_pid(Pid) ->
     case ssl_gen_statem:connection_information(Pid, include_security_info(Items)) of
         {ok, Info} ->
             {ok, [Item || Item = {Key, Value} <- Info,  lists:member(Key, Items),
@@ -1075,14 +1075,14 @@ prepend_cipher_suites([First | _] = Preferred, Suites0) when is_map(First) ->
     Suites = Preferred ++ (Suites0 -- Preferred),
     Suites;
 prepend_cipher_suites(Filters, Suites) ->
-    Preferred = filter_cipher_suites(Suites, Filters), 
+    Preferred = filter_cipher_suites(Suites, Filters),
     Preferred ++ (Suites -- Preferred).
 %%--------------------------------------------------------------------
 -spec append_cipher_suites(Deferred, Suites) -> ciphers() when
       Deferred :: ciphers() | cipher_filters(),
       Suites :: ciphers().
 
-%% Description: Make <Deferred> suites suites become the 
+%% Description: Make <Deferred> suites suites become the
 %% least preferred suites that is put them at the end of the cipher suite list
 %% and removed them from <Suites> if present.
 %%
@@ -1091,7 +1091,7 @@ append_cipher_suites([First | _] = Deferred, Suites0) when is_map(First)->
     Suites = (Suites0 -- Deferred) ++ Deferred,
     Suites;
 append_cipher_suites(Filters, Suites) ->
-    Deferred = filter_cipher_suites(Suites, Filters), 
+    Deferred = filter_cipher_suites(Suites, Filters),
     (Suites -- Deferred) ++  Deferred.
 
 %%--------------------------------------------------------------------
@@ -1280,7 +1280,7 @@ shutdown(#sslsocket{pid = {dtls, #config{}}},_) ->
     {error, enotconn};
 shutdown(#sslsocket{pid = {Listen, #config{transport_info = Info}}}, How) ->
     Transport = element(1, Info),
-    Transport:shutdown(Listen, How);    
+    Transport:shutdown(Listen, How);
 shutdown(#sslsocket{pid = [Pid|_]}, How) when is_pid(Pid) ->
     ssl_gen_statem:shutdown(Pid, How).
 
@@ -1317,22 +1317,22 @@ versions() ->
     ImplementedTLSVsns =  ?ALL_AVAILABLE_VERSIONS,
     ImplementedDTLSVsns = ?ALL_AVAILABLE_DATAGRAM_VERSIONS,
 
-     TLSCryptoSupported = fun(Vsn) -> 
+     TLSCryptoSupported = fun(Vsn) ->
                                   tls_record:sufficient_crypto_support(Vsn)
                           end,
-     DTLSCryptoSupported = fun(Vsn) -> 
-                                   tls_record:sufficient_crypto_support(dtls_v1:corresponding_tls_version(Vsn))  
+     DTLSCryptoSupported = fun(Vsn) ->
+                                   tls_record:sufficient_crypto_support(dtls_v1:corresponding_tls_version(Vsn))
                            end,
     SupportedTLSVsns = [tls_record:protocol_version(Vsn) || Vsn <- ConfTLSVsns,  TLSCryptoSupported(Vsn)],
     SupportedDTLSVsns = [dtls_record:protocol_version(Vsn) || Vsn <- ConfDTLSVsns, DTLSCryptoSupported(Vsn)],
 
     AvailableTLSVsns = [Vsn || Vsn <- ImplementedTLSVsns, TLSCryptoSupported(tls_record:protocol_version(Vsn))],
     AvailableDTLSVsns = [Vsn || Vsn <- ImplementedDTLSVsns, DTLSCryptoSupported(dtls_record:protocol_version(Vsn))],
-                                    
-    [{ssl_app, ?VSN}, 
-     {supported, SupportedTLSVsns}, 
-     {supported_dtls, SupportedDTLSVsns}, 
-     {available, AvailableTLSVsns}, 
+
+    [{ssl_app, ?VSN},
+     {supported, SupportedTLSVsns},
+     {supported_dtls, SupportedDTLSVsns},
+     {available, AvailableTLSVsns},
      {available_dtls, AvailableDTLSVsns},
      {implemented, ImplementedTLSVsns},
      {implemented_dtls, ImplementedDTLSVsns}
@@ -1462,7 +1462,7 @@ suite_to_str(Cipher) ->
 
 %%--------------------------------------------------------------------
 -spec suite_to_openssl_str(CipherSuite) -> string() when
-      CipherSuite :: erl_cipher_suite().                
+      CipherSuite :: erl_cipher_suite().
 %%
 %% Description: Return the string representation of a cipher suite.
 %%--------------------------------------------------------------------
@@ -1488,7 +1488,7 @@ str_to_suite(CipherSuiteName) ->
         _:_ ->
             {error, {not_recognized, CipherSuiteName}}
     end.
-           
+
 %%%--------------------------------------------------------------
 %%% Internal functions
 %%%--------------------------------------------------------------------
@@ -1496,9 +1496,9 @@ supported_suites(exclusive, {3,Minor}) ->
     tls_v1:exclusive_suites(Minor);
 supported_suites(exclusive, {254, Minor}) ->
     dtls_v1:exclusive_suites(Minor);
-supported_suites(default, Version) ->  
+supported_suites(default, Version) ->
     ssl_cipher:suites(Version);
-supported_suites(all, Version) ->  
+supported_suites(all, Version) ->
     ssl_cipher:all_suites(Version);
 supported_suites(anonymous, Version) ->
     ssl_cipher:anonymous_suites(Version);
@@ -1512,15 +1512,15 @@ do_listen(Port, #config{transport_info = {Transport, _, _, _,_}} = Config, tls_g
 
 do_listen(Port,  Config, dtls_gen_connection) ->
     dtls_socket:listen(Port, Config).
-	
+
 -spec handle_options([any()], client | server) -> {ok, #config{}};
                     ([any()], ssl_options()) -> ssl_options().
 
 handle_options(Opts, Role) ->
-    handle_options(undefined, undefined, Opts, Role, undefined).   
+    handle_options(undefined, undefined, Opts, Role, undefined).
 
 handle_options(Opts, Role, InheritedSslOpts) ->
-    handle_options(undefined, undefined, Opts, Role, InheritedSslOpts).   
+    handle_options(undefined, undefined, Opts, Role, InheritedSslOpts).
 
 %% Handle ssl options at handshake, handshake_continue
 handle_options(_, _, Opts0, Role, InheritedSslOpts) when is_map(InheritedSslOpts) ->
@@ -1530,7 +1530,7 @@ handle_options(_, _, Opts0, Role, InheritedSslOpts) when is_map(InheritedSslOpts
 %% Handle all options in listen, connect and handshake
 handle_options(Transport, Socket, Opts0, Role, Host) ->
     {SslOpts0, SockOpts0} = expand_options(Opts0, ?RULES),
-    
+
     %% Ensure all options are evaluated at startup
     SslOpts1 = add_missing_options(SslOpts0, ?RULES),
     SslOpts2 = #{protocol := Protocol}
@@ -1539,7 +1539,7 @@ handle_options(Transport, Socket, Opts0, Role, Host) ->
                           #{role => Role,
                             host => Host,
                             rules => ?RULES}),
-    
+
     maybe_client_warn_no_verify(SslOpts2, Role),
     SslOpts = maps:without([warn_verify_none], SslOpts2),
     %% Handle special options
@@ -1990,7 +1990,7 @@ expand_options(Opts0, Rules) ->
                                 cb_info,
                                 client_preferred_next_protocols,  %% next_protocol_selector
                                 log_alert]),                      %% obsoleted by log_level
-    
+
     SslOpts0 = Opts -- SockOpts,
     SslOpts = {SslOpts0, [], length(SslOpts0)},
     {SslOpts, SockOpts}.
@@ -2139,6 +2139,10 @@ validate_option(certfile, Value, _)
 validate_option(certfile, Value, _)
   when is_list(Value) ->
     binary_filename(Value);
+validate_option(certificate_status, Value = #certificate_status{}, _) ->
+    Value;
+validate_option(certificate_status, Value = undefined, _) ->
+    Value;
 validate_option(client_preferred_next_protocols, {Precedence, PreferredProtocols}, _)
   when is_list(PreferredProtocols) ->
     validate_binary_list(client_preferred_next_protocols, PreferredProtocols),
@@ -2475,12 +2479,12 @@ handle_hashsigns_option(Value, Version) when is_list(Value)
 	_ ->
 	    Value
     end;
-handle_hashsigns_option(Value, Version) when is_list(Value) 
+handle_hashsigns_option(Value, Version) when is_list(Value)
                                              andalso Version =:= {3, 3} ->
     case tls_v1:signature_algs(Version, Value) of
 	[] ->
 	    throw({error, {options, no_supported_algorithms, {signature_algs, Value}}});
-	_ ->	
+	_ ->
 	    Value
     end;
 handle_hashsigns_option(_, Version) when Version =:= {3, 3} ->
@@ -2533,7 +2537,7 @@ validate_versions([Version | Rest], Versions) when Version == 'tlsv1.3';
             tls_validate_versions(Rest, Versions);
         false ->
             throw({error, {options, {insufficient_crypto_support, {Version, {versions, Versions}}}}})
-    end; 
+    end;
 validate_versions([Version | Rest], Versions) when Version == 'dtlsv1';
                                                    Version == 'dtlsv1.2'->
     DTLSVer = dtls_record:protocol_version(Version),
@@ -2542,7 +2546,7 @@ validate_versions([Version | Rest], Versions) when Version == 'dtlsv1';
             dtls_validate_versions(Rest, Versions);
         false ->
             throw({error, {options, {insufficient_crypto_support, {Version, {versions, Versions}}}}})
-    end;        
+    end;
 validate_versions([Version| _], Versions) ->
     throw({error, {options, {Version, {versions, Versions}}}}).
 
@@ -2552,7 +2556,7 @@ tls_validate_versions([Version | Rest], Versions) when Version == 'tlsv1.3';
                                                        Version == 'tlsv1.2';
                                                        Version == 'tlsv1.1';
                                                        Version == tlsv1 ->
-    tls_validate_versions(Rest, Versions);                  
+    tls_validate_versions(Rest, Versions);
 tls_validate_versions([Version| _], Versions) ->
     throw({error, {options, {Version, {versions, Versions}}}}).
 
@@ -2603,7 +2607,7 @@ emulated_options(Transport, Socket, Protocol, Opts) ->
     {Inet, Emulated0} = emulated_options(undefined, undefined, Protocol, Opts),
     {Inet, lists:ukeymerge(1, Emulated0, Original)}.
 
-handle_cipher_option(Value, Versions)  when is_list(Value) ->       
+handle_cipher_option(Value, Versions)  when is_list(Value) ->
     try binary_cipher_suites(Versions, Value) of
 	Suites ->
 	    Suites
@@ -2614,12 +2618,12 @@ handle_cipher_option(Value, Versions)  when is_list(Value) ->
 	    throw({error, {options, {ciphers, Value}}})
     end.
 
-binary_cipher_suites([{3,4} = Version], []) -> 
+binary_cipher_suites([{3,4} = Version], []) ->
     %% Defaults to all supported suites that does
     %% not require explicit configuration TLS-1.3
     %% only mode.
     default_binary_suites(exclusive, Version);
-binary_cipher_suites([Version| _], []) -> 
+binary_cipher_suites([Version| _], []) ->
     %% Defaults to all supported suites that does
     %% not require explicit configuration
     default_binary_suites(default, Version);
@@ -2675,9 +2679,9 @@ tuple_to_map({Kex, Cipher, Mac, Prf}) ->
       prf => Prf}.
 
 %% Backwards compatible
-tuple_to_map_mac(aes_128_gcm, _) -> 
+tuple_to_map_mac(aes_128_gcm, _) ->
     aead;
-tuple_to_map_mac(aes_256_gcm, _) -> 
+tuple_to_map_mac(aes_256_gcm, _) ->
     aead;
 tuple_to_map_mac(chacha20_poly1305, _) ->
     aead;
@@ -2781,20 +2785,20 @@ binary_filename(FileName) ->
     unicode:characters_to_binary(FileName, unicode, Enc).
 
 %% Assert that basic options are on the format {Key, Value}
-%% with a few exceptions and phase out log_alert 
+%% with a few exceptions and phase out log_alert
 handle_option_format([], Acc) ->
     lists:reverse(Acc);
 handle_option_format([{log_alert, Bool} | Rest], Acc) when is_boolean(Bool) ->
     case proplists:get_value(log_level, Acc ++ Rest, undefined) of
-        undefined -> 
-            handle_option_format(Rest, [{log_level, 
+        undefined ->
+            handle_option_format(Rest, [{log_level,
                                          map_log_level(Bool)} | Acc]);
-        _ ->                             
+        _ ->
             handle_option_format(Rest, Acc)
-    end;                             
+    end;
 handle_option_format([{Key,_} = Opt | Rest], Acc) when is_atom(Key) ->
     handle_option_format(Rest, [Opt | Acc]);
-%% Handle exceptions 
+%% Handle exceptions
 handle_option_format([{raw,_,_,_} = Opt | Rest], Acc) ->
     handle_option_format(Rest,  [Opt | Acc]);
 handle_option_format([inet = Opt | Rest], Acc) ->

--- a/lib/ssl/src/ssl_handshake.erl
+++ b/lib/ssl/src/ssl_handshake.erl
@@ -90,7 +90,7 @@
          path_validation_alert/1]).
 
 %%====================================================================
-%% Create handshake messages 
+%% Create handshake messages
 %%====================================================================
 
 %%--------------------------------------------------------------------
@@ -109,7 +109,7 @@ hello_request() ->
 %% Description: Creates a server hello message.
 %%--------------------------------------------------------------------
 server_hello(SessionId, Version, ConnectionStates, Extensions) ->
-    #{security_parameters := SecParams} = 
+    #{security_parameters := SecParams} =
 	ssl_record:pending_connection_state(ConnectionStates, read),
     #server_hello{server_version = Version,
 		  cipher_suite = SecParams#security_parameters.cipher_suite,
@@ -170,7 +170,7 @@ client_certificate_verify([OwnCert|_], MasterSecret, Version,
     end.
 
 %%--------------------------------------------------------------------
--spec certificate_request(db_handle(), 
+-spec certificate_request(db_handle(),
 			  certdb_ref(),  #hash_sign_algos{}, ssl_record:ssl_version()) ->
 				 #certificate_request{}.
 %%
@@ -327,7 +327,7 @@ next_protocol(SelectedProtocol) ->
   #next_protocol{selected_protocol = SelectedProtocol}.
 
 %%====================================================================
-%% Handle handshake messages 
+%% Handle handshake messages
 %%====================================================================
 %%--------------------------------------------------------------------
 -spec certify(#certificate{}, db_handle(), certdb_ref(), ssl_options(), term(),
@@ -338,7 +338,7 @@ next_protocol(SelectedProtocol) ->
 %%--------------------------------------------------------------------
 certify(#certificate{asn1_certificates = ASN1Certs}, CertDbHandle, CertDbRef,
         #{server_name_indication := ServerNameIndication,
-          partial_chain := PartialChain} = SSlOptions, 
+          partial_chain := PartialChain} = SSlOptions,
         CRLDbHandle, Role, Host, Version, CertExt) ->
     ServerName = server_name(ServerNameIndication, Host, Role),
     [PeerCert | _ChainCerts ] = ASN1Certs,
@@ -346,7 +346,7 @@ certify(#certificate{asn1_certificates = ASN1Certs}, CertDbHandle, CertDbRef,
 	PathsAndAnchors  =
 	    ssl_certificate:trusted_cert_and_paths(ASN1Certs, CertDbHandle, CertDbRef,
                                                    PartialChain),
-        
+
 	case path_validate(PathsAndAnchors, ServerName, Role, CertDbHandle, CertDbRef, CRLDbHandle,
                            Version, SSlOptions, CertExt) of
 	    {ok, {PublicKeyInfo, _}} ->
@@ -434,7 +434,7 @@ master_secret(Version, #session{master_secret = Mastersecret},
 master_secret(Version, PremasterSecret, ConnectionStates, Role) ->
     #{security_parameters := SecParams} =
 	ssl_record:pending_connection_state(ConnectionStates, read),
-    
+
     #security_parameters{prf_algorithm = PrfAlgo,
 			 client_random = ClientRandom,
 			 server_random = ServerRandom} = SecParams,
@@ -530,7 +530,7 @@ select_supported_version([ClientVersion|T], ServerVersions) ->
 
 
 %%====================================================================
-%% Encode handshake 
+%% Encode handshake
 %%====================================================================
 
 encode_handshake(#next_protocol{selected_protocol = SelectedProtocol}, _Version) ->
@@ -583,6 +583,9 @@ encode_handshake(#certificate_request{certificate_types = CertTypes,
        <<?BYTE(CertTypesLen), CertTypes/binary,
 	?UINT16(CertAuthsLen), EncCertAuths/binary>>
     };
+encode_handshake(#certificate_status{status_type = StatusType, response = Response}, _Version) ->
+    Size = byte_size(Response),
+    {?CERTIFICATE_STATUS, <<?BYTE(StatusType), ?UINT24(Size), Response/binary>>};
 encode_handshake(#server_hello_done{}, _Version) ->
     {?SERVER_HELLO_DONE, <<>>};
 encode_handshake(#client_key_exchange{exchange_keys = ExchangeKeys}, Version) ->
@@ -600,7 +603,7 @@ encode_hello_extensions(Extensions, _) ->
 
 encode_extensions(Exts) ->
     encode_extensions(Exts, <<>>).
-    
+
 encode_extensions([], <<>>) ->
     <<?UINT16(0)>>;
 encode_extensions([], Acc) ->
@@ -639,7 +642,7 @@ encode_extensions([#supported_groups{supported_groups = SupportedGroups} | Rest]
     ListLen = byte_size(SupportedGroupList),
     Len = ListLen + 2,
     encode_extensions(Rest, <<?UINT16(?ELLIPTIC_CURVES_EXT),
-                              ?UINT16(Len), ?UINT16(ListLen), 
+                              ?UINT16(Len), ?UINT16(ListLen),
                               SupportedGroupList/binary, Acc/binary>>);
 encode_extensions([#ec_point_formats{ec_point_format_list = ECPointFormats} | Rest], Acc) ->
     ECPointFormatList = list_to_binary(ECPointFormats),
@@ -776,10 +779,31 @@ encode_cert_status_req(
     StatusType,
     #ocsp_status_request{
         responder_id_list = ResponderIDList,
-        request_extensions = ReqExtns}) ->
+        request_extensions = ReqExtns} = Value) ->
+    io:format(user, "~n~n~p:~p:~p >>>>>>>>>>>>>>>>>>>>>> ocsp_status_req ~n  ~p~n~n",
+              [?MODULE, ?FUNCTION_NAME, ?LINE,
+               #{ status_type => StatusType
+                , value => Value
+                }]),
     ResponderIDListBin = encode_responderID_list(ResponderIDList),
     ReqExtnsBin = encode_request_extensions(ReqExtns),
-    <<?BYTE(StatusType), ResponderIDListBin/binary, ReqExtnsBin/binary>>.
+    <<?BYTE(StatusType), ResponderIDListBin/binary, ReqExtnsBin/binary>>;
+encode_cert_status_req(StatusType, #certificate_status{} = Status) ->
+    io:format(user, "~n~n~p:~p:~p >>>>>>>>>>>>>>>>>>>>>> ocsp_response ~n  ~p~n~n",
+              [?MODULE, ?FUNCTION_NAME, ?LINE,
+               #{ status_type => StatusType
+                , value => Status
+                }]),
+    Version = {3, 4},
+    {_, EncStatus} = encode_handshake(Status, Version),
+    EncStatus;
+encode_cert_status_req(StatusType, Value) ->
+    io:format(user, "~n~n~p:~p:~p >>>>>>>>>>>>>>>>>>>>>> something else ~n  ~p~n~n",
+              [?MODULE, ?FUNCTION_NAME, ?LINE,
+               #{ status_type => StatusType
+                , value => Value
+                }]),
+    <<>>.
 
 encode_responderID_list([]) ->
     <<?UINT16(0)>>;
@@ -822,15 +846,15 @@ encode_protocols_advertised_on_server(Protocols) ->
 encode_cert_auths(Auths) ->
     encode_cert_auths(Auths, []).
 
-encode_cert_auths([], Acc) -> 
+encode_cert_auths([], Acc) ->
     list_to_binary(lists:reverse(Acc));
 encode_cert_auths([Auth | Auths], Acc) ->
-    DNEncodedBin = public_key:pkix_encode('Name', Auth, otp),   
+    DNEncodedBin = public_key:pkix_encode('Name', Auth, otp),
     DNEncodedLen = byte_size(DNEncodedBin),
     encode_cert_auths(Auths, [<<?UINT16(DNEncodedLen), DNEncodedBin/binary>> | Acc]).
 
 %%====================================================================
-%% Decode handshake 
+%% Decode handshake
 %%====================================================================
 
 decode_handshake(_, ?HELLO_REQUEST, <<>>) ->
@@ -910,7 +934,7 @@ decode_handshake(_, MessageType, _) ->
 %%
 %% Description: Remove length tag from TLS Vector type. Needed
 %% for client hello when extensions in older versions may be empty.
-%% 
+%%
 %%--------------------------------------------------------------------
 decode_vector(<<>>) ->
     <<>>;
@@ -997,7 +1021,7 @@ available_suites(ServerCert, UserSuites, Version, undefined, Curve) ->
     filter_unavailable_ecc_suites(Curve, Suites);
 available_suites(ServerCert, UserSuites, Version, HashSigns, Curve) ->
     Suites = available_suites(ServerCert, UserSuites, Version, undefined, Curve),
-    filter_hashsigns(Suites, [ssl_cipher_format:suite_bin_to_map(Suite) || Suite <- Suites], HashSigns, 
+    filter_hashsigns(Suites, [ssl_cipher_format:suite_bin_to_map(Suite) || Suite <- Suites], HashSigns,
                      Version, []).
 
 available_signature_algs(undefined, _)  ->
@@ -1005,7 +1029,7 @@ available_signature_algs(undefined, _)  ->
 available_signature_algs(SupportedHashSigns, Version) when Version >= {3, 3} ->
     case contains_scheme(SupportedHashSigns) of
         true ->
-            case Version of 
+            case Version of
                 {3,3} ->
                     #hash_sign_algos{hash_sign_algos = ssl_cipher:signature_schemes_1_2(SupportedHashSigns)};
                 _ ->
@@ -1020,7 +1044,7 @@ available_signature_algs(_, _) ->
 available_signature_algs(undefined, SupportedHashSigns, Version) when
       Version >= {3,3} ->
     SupportedHashSigns;
-available_signature_algs(#hash_sign_algos{hash_sign_algos = ClientHashSigns}, SupportedHashSigns0, 
+available_signature_algs(#hash_sign_algos{hash_sign_algos = ClientHashSigns}, SupportedHashSigns0,
                          Version) when Version >= {3,3} ->
     SupportedHashSigns =
         case (Version == {3,3}) andalso contains_scheme(SupportedHashSigns0) of
@@ -1029,7 +1053,7 @@ available_signature_algs(#hash_sign_algos{hash_sign_algos = ClientHashSigns}, Su
             false ->
                 SupportedHashSigns0
         end,
-    sets:to_list(sets:intersection(sets:from_list(ClientHashSigns), 
+    sets:to_list(sets:intersection(sets:from_list(ClientHashSigns),
 				   sets:from_list(SupportedHashSigns)));
 available_signature_algs(_, _, _) ->
     undefined.
@@ -1134,17 +1158,17 @@ supported_ecc(_) ->
     #elliptic_curves{elliptic_curve_list = []}.
 
 premaster_secret(OtherPublicDhKey, MyPrivateKey, #'DHParameter'{} = Params) ->
-    try 
-	public_key:compute_key(OtherPublicDhKey, MyPrivateKey, Params)  
-    catch 
-	error:computation_failed -> 
+    try
+	public_key:compute_key(OtherPublicDhKey, MyPrivateKey, Params)
+    catch
+	error:computation_failed ->
 	    throw(?ALERT_REC(?FATAL, ?ILLEGAL_PARAMETER))
-    end;	   
+    end;
 premaster_secret(PublicDhKey, PrivateDhKey, #server_dh_params{dh_p = Prime, dh_g = Base}) ->
-    try 
+    try
 	crypto:compute_key(dh, PublicDhKey, PrivateDhKey, [Prime, Base])
-    catch 
-	error:computation_failed -> 
+    catch
+	error:computation_failed ->
 	    throw(?ALERT_REC(?FATAL, ?ILLEGAL_PARAMETER))
     end;
 premaster_secret(#client_srp_public{srp_a = ClientPublicKey}, ServerKey, #srp_user{prime = Prime,
@@ -1478,7 +1502,7 @@ handle_client_hello_extensions(RecordCB, Random, ClientCipherSuites,
     MaxFragEnum = handle_mfl_extension(maps:get(max_frag_enum, Exts, undefined)),
     ConnectionStates1 = ssl_record:set_max_fragment_length(MaxFragEnum, ConnectionStates0),
     ConnectionStates = handle_renegotiation_extension(server, RecordCB, Version, maps:get(renegotiation_info, Exts, undefined),
-						      Random, NegotiatedCipherSuite, 
+						      Random, NegotiatedCipherSuite,
 						      ClientCipherSuites, Compression,
 						      ConnectionStates1, Renegotiation, SecureRenegotation),
 
@@ -1491,11 +1515,12 @@ handle_client_hello_extensions(RecordCB, Random, ClientCipherSuites,
                         end,
     ServerHelloExtensions = Empty#{renegotiation_info => renegotiation_info(RecordCB, server,
                                                                             ConnectionStates, Renegotiation),
-                                   ec_point_formats => server_ecc_extension(Version, 
+                                   ec_point_formats => server_ecc_extension(Version,
                                                                             maps:get(ec_point_formats, Exts, undefined)),
-                                   max_frag_enum => ServerMaxFragEnum
+                                   max_frag_enum => ServerMaxFragEnum,
+                                   status_request => handle_status_request(Opts, Exts)
                                   },
-    
+
     %% If we receive an ALPN extension and have ALPN configured for this connection,
     %% we handle it. Otherwise we check for the NPN extension.
     ALPN = maps:get(alpn, Exts, undefined),
@@ -1518,8 +1543,8 @@ handle_server_hello_extensions(RecordCB, Random, CipherSuite, Compression,
                                  next_protocol_selector := NextProtoSelector,
                                  ocsp_stapling := Stapling},
 			       ConnectionStates0, Renegotiation, IsNew) ->
-    ConnectionStates = handle_renegotiation_extension(client, RecordCB, Version,  
-                                                      maps:get(renegotiation_info, Exts, undefined), Random, 
+    ConnectionStates = handle_renegotiation_extension(client, RecordCB, Version,
+                                                      maps:get(renegotiation_info, Exts, undefined), Random,
 						      CipherSuite, undefined,
 						      Compression, ConnectionStates0,
 						      Renegotiation, SecureRenegotation),
@@ -1566,6 +1591,23 @@ handle_server_hello_extensions(RecordCB, Random, CipherSuite, Compression,
             end
     end.
 
+handle_status_request(SSLOptions, ClientExtensions) ->
+    io:format(user, "~n~n~p:~p:~p >>>>>>>>>>>>>>>>>>>>>> opts:~n ~p~n~n",
+              [?MODULE, ?FUNCTION_NAME, ?LINE, SSLOptions]),
+    io:format(user, "~n~n~p:~p:~p >>>>>>>>>>>>>>>>>>>>>> client exts:~n ~p~n~n",
+              [?MODULE, ?FUNCTION_NAME, ?LINE, ClientExtensions]),
+    case {SSLOptions, ClientExtensions} of
+        { #{certificate_status := #certificate_status{}}
+        , #{status_request := #certificate_status_request{}}
+        } ->
+            #certificate_status_request{
+               status_type = ?CERTIFICATE_STATUS_TYPE_OCSP,
+               request = <<>>
+              };
+        _ ->
+            undefined
+    end.
+
 select_curve(Client, Server, Version) ->
     select_curve(Client, Server, Version, false).
 
@@ -1580,7 +1622,7 @@ select_curve(#elliptic_curves{elliptic_curve_list = ClientCurves},
             select_shared_curve(ServerCurves, ClientCurves)
     end;
 select_curve(undefined, _, {_,Minor}, _) ->
-    %% Client did not send ECC extension use default curve if 
+    %% Client did not send ECC extension use default curve if
     %% ECC cipher is negotiated
     case tls_v1:ecc_curves(Minor, [secp256r1]) of
         [] ->
@@ -1601,7 +1643,7 @@ select_curve({supported_groups, Groups}, Server,{_, Minor} = Version, HonorServe
     end.
 
 %%--------------------------------------------------------------------
--spec select_hashsign(#hash_sign_algos{} | undefined,  undefined | binary(), 
+-spec select_hashsign(#hash_sign_algos{} | undefined,  undefined | binary(),
 		      atom(), [atom()], ssl_record:ssl_version()) ->
 			     {atom(), atom()} | undefined  | #alert{}.
 
@@ -1667,12 +1709,12 @@ select_hashsign(_, Cert, _, _, Version) ->
     #'OTPSubjectPublicKeyInfo'{algorithm = {_,Algo, _}} = TBSCert#'OTPTBSCertificate'.subjectPublicKeyInfo,
     select_hashsign_algs(undefined, Algo, Version).
 %%--------------------------------------------------------------------
--spec select_hashsign(#certificate_request{},  binary(), 
+-spec select_hashsign(#certificate_request{},  binary(),
 		      [atom()], ssl_record:ssl_version()) ->
 			     {atom(), atom()} | #alert{}.
 
 %%
-%% Description: Handles signature algorithms selection for certificate requests (client) 
+%% Description: Handles signature algorithms selection for certificate requests (client)
 %%--------------------------------------------------------------------
 select_hashsign(#certificate_request{
                    hashsign_algorithms = #hash_sign_algos{
@@ -1878,7 +1920,7 @@ select_hashsign_algs(undefined, ?rsaEncryption, {3,3})  ->
     {sha, rsa};
 select_hashsign_algs(undefined,?'id-ecPublicKey', _) ->
     {sha, ecdsa};
-select_hashsign_algs(undefined, ?rsaEncryption, _) -> 
+select_hashsign_algs(undefined, ?rsaEncryption, _) ->
     {md5sha, rsa};
 select_hashsign_algs(undefined, ?'id-dsa', _) ->
     {sha, dsa}.
@@ -2028,8 +2070,8 @@ validation_fun_and_state(undefined, VerifyState, CertPath, LogLevel) ->
 	     ssl_certificate:validate(OtpCert,
 				      Extension,
 				      SslState);
-	(OtpCert, VerifyResult, SslState) when (VerifyResult == valid) or 
-                                               (VerifyResult == valid_peer) -> 
+	(OtpCert, VerifyResult, SslState) when (VerifyResult == valid) or
+                                               (VerifyResult == valid_peer) ->
 	     case cert_status_check(OtpCert, SslState, VerifyResult, CertPath, LogLevel) of
 		 valid ->
                      ssl_certificate:validate(OtpCert, VerifyResult, SslState);
@@ -2067,7 +2109,7 @@ apply_user_fun(Fun, OtpCert, ExtensionOrError, UserState0, SslState, _CertPath, 
     end.
 
 maybe_check_hostname(OtpCert, valid_peer, SslState) ->
-    case ssl_certificate:validate(OtpCert, valid_peer, SslState) of 
+    case ssl_certificate:validate(OtpCert, valid_peer, SslState) of
         {valid, _} ->
             valid_peer;
         {fail, Reason} ->
@@ -2129,7 +2171,7 @@ do_digitally_signed(_, Msg, HashAlgo, Key, SignAlgo) ->
     Options = signature_options(SignAlgo, HashAlgo),
     public_key:sign(Msg, HashAlgo, Key, Options).
 
-    
+
 signature_options(SignAlgo, HashAlgo) when SignAlgo =:= rsa_pss_rsae orelse
                                            SignAlgo =:= rsa_pss_pss ->
     pss_options(HashAlgo);
@@ -2170,7 +2212,7 @@ cert_status_check(_OtpCert, #{ocsp_state := #{ocsp_stapling := true,
                   _VerifyResult, _CertPath, _LogLevel) ->
     {bad_cert, {revocation_status_undetermined, not_stapled}};
 cert_status_check(OtpCert, #{ocsp_state := #{ocsp_stapling := best_effort, %% TODO support this ?
-                                             ocsp_expect := undetermined}} = SslState, 
+                                             ocsp_expect := undetermined}} = SslState,
                   VerifyResult, CertPath, LogLevel) ->
     maybe_check_crl(OtpCert, SslState, VerifyResult, CertPath, LogLevel);
 cert_status_check(_OtpCert, #{ocsp_state := #{ocsp_stapling := true,
@@ -2182,14 +2224,14 @@ maybe_check_crl(_, #{crl_check := false}, _, _, _) ->
     valid;
 maybe_check_crl(_, #{crl_check := peer}, valid, _, _) -> %% Do not check CAs with this option.
     valid;
-maybe_check_crl(OtpCert, #{crl_check := Check, 
+maybe_check_crl(OtpCert, #{crl_check := Check,
                      certdb := CertDbHandle,
                      certdb_ref := CertDbRef,
                      crl_db := {Callback, CRLDbHandle}}, _, CertPath, LogLevel) ->
     Options = [{issuer_fun, {fun(_DP, CRL, Issuer, DBInfo) ->
 				     ssl_crl:trusted_cert_and_path(CRL, Issuer, CertPath,
                                                                    DBInfo)
-			     end, {CertDbHandle, CertDbRef}}}, 
+			     end, {CertDbHandle, CertDbRef}}},
 	       {update_crl, fun(DP, CRL) ->
                                     case Callback:fresh_crl(DP, CRL) of
                                         {logger, LogInfo, Fresh} ->
@@ -2206,26 +2248,26 @@ maybe_check_crl(OtpCert, #{crl_check := Check,
 	    crl_check_same_issuer(OtpCert, Check,
 				  dps_and_crls(OtpCert, Callback, CRLDbHandle, same_issuer, LogLevel),
 				  Options);
-	DpsAndCRLs ->  %% This DP list may be empty if relevant CRLs existed 
+	DpsAndCRLs ->  %% This DP list may be empty if relevant CRLs existed
 	    %% but could not be retrieved, will result in {bad_cert, revocation_status_undetermined}
 	    case public_key:pkix_crls_validate(OtpCert, DpsAndCRLs, Options) of
 		{bad_cert, {revocation_status_undetermined, _}} ->
-		    crl_check_same_issuer(OtpCert, Check, 
-                                          dps_and_crls(OtpCert, Callback, 
+		    crl_check_same_issuer(OtpCert, Check,
+                                          dps_and_crls(OtpCert, Callback,
                                                        CRLDbHandle, same_issuer, LogLevel), Options);
 		Other ->
 		    Other
 	    end
     end.
 
-crl_check_same_issuer(OtpCert, best_effort, Dps, Options) ->		
-    case public_key:pkix_crls_validate(OtpCert, Dps, Options) of 
+crl_check_same_issuer(OtpCert, best_effort, Dps, Options) ->
+    case public_key:pkix_crls_validate(OtpCert, Dps, Options) of
 	{bad_cert, {revocation_status_undetermined, _}}   ->
 	    valid;
 	Other ->
 	    Other
     end;
-crl_check_same_issuer(OtpCert, _, Dps, Options) ->    
+crl_check_same_issuer(OtpCert, _, Dps, Options) ->
     public_key:pkix_crls_validate(OtpCert, Dps, Options).
 
 dps_and_crls(OtpCert, Callback, CRLDbHandle, ext, LogLevel) ->
@@ -2238,10 +2280,10 @@ dps_and_crls(OtpCert, Callback, CRLDbHandle, ext, LogLevel) ->
             dps_and_crls(DistPoints, CRLs, [])
     end;
 
-dps_and_crls(OtpCert, Callback, CRLDbHandle, same_issuer, LogLevel) ->    
-    DP = #'DistributionPoint'{distributionPoint = {fullName, GenNames}} = 
+dps_and_crls(OtpCert, Callback, CRLDbHandle, same_issuer, LogLevel) ->
+    DP = #'DistributionPoint'{distributionPoint = {fullName, GenNames}} =
 	public_key:pkix_dist_point(OtpCert),
-    CRLs = lists:flatmap(fun({directoryName, Issuer}) -> 
+    CRLs = lists:flatmap(fun({directoryName, Issuer}) ->
 				 case Callback:select(Issuer, CRLDbHandle) of
                                      {logger, LogInfo, Return} ->
                                          handle_log(LogLevel, LogInfo),
@@ -2259,7 +2301,7 @@ dps_and_crls([], _, Acc) ->
 dps_and_crls([DP | Rest], CRLs, Acc) ->
     DpCRL = [{DP, {CRL, public_key:der_decode('CertificateList', CRL)}} ||  CRL <- CRLs],
     dps_and_crls(Rest, CRLs, DpCRL ++ Acc).
-    
+
 distpoints_lookup([],_, _, _, _) ->
     [];
 distpoints_lookup([DistPoint | Rest], Issuer, Callback, CRLDbHandle, LogLevel) ->
@@ -2329,7 +2371,7 @@ setup_keys({3,N}, PrfAlgo, MasterSecret,
 			KML, IVS).
 calc_master_secret({3,_}, PrfAlgo, PremasterSecret, ClientRandom, ServerRandom) ->
     tls_v1:master_secret(PrfAlgo, PremasterSecret, ClientRandom, ServerRandom).
-	
+
 %% Update pending connection states with parameters exchanged via
 %% hello messages
 %% NOTE : Role is the role of the receiver of the hello message
@@ -3069,7 +3111,33 @@ decode_extensions(<<?UINT16(?STATUS_REQUEST), ?UINT16(Len),
           ASN1OCSPResponse:OCSPLen/binary>> ->
             decode_extensions(Rest, Version, MessageType,
                       Acc#{status_request => #certificate_status{response = ASN1OCSPResponse}});
+        <<?BYTE(?CERTIFICATE_STATUS_TYPE_OCSP),
+          ?UINT16(0),
+          ?UINT16(0)>> ->
+            io:format(user, "~n~n~p:~p:~p >>>>>>>>>>>>>>>>>>>>>> status_request patch:~n ~p~n~n",
+                      [?MODULE, ?FUNCTION_NAME, ?LINE,
+                       #{ cert_status => CertStatus
+                        , len => Len
+                        , msg_type => MessageType
+                        , version => Version
+                        , type_enc => <<?UINT16(?STATUS_REQUEST)>>
+                        , len_enc => <<?UINT16(Len)>>
+                        , zero_enc => <<?UINT24(0)>>
+                        }]),
+            decode_extensions(Rest, Version, MessageType,
+              Acc#{status_request => #certificate_status_request{}});
         _Other ->
+            io:format(user, "~n~n~p:~p:~p >>>>>>>>>>>>>>>>>>>>>> status_request other:~n ~p~n~n",
+                      [?MODULE, ?FUNCTION_NAME, ?LINE,
+                       #{ other => _Other
+                        , cert_status => CertStatus
+                        , len => Len
+                        , msg_type => MessageType
+                        , version => Version
+                        , type_enc => <<?UINT16(?STATUS_REQUEST)>>
+                        , len_enc => <<?UINT16(Len)>>
+                        , zero_enc => <<?UINT24(0)>>
+                        }]),
             decode_extensions(Rest, Version, MessageType, Acc)
     end;
 
@@ -3084,7 +3152,7 @@ decode_extensions(<<?UINT16(?EARLY_DATA_EXT), ?UINT16(4), ?UINT32(MaxSize),
     decode_extensions(Rest, Version, MessageType,
                       Acc#{early_data =>
                                #early_data_indication_nst{indication = MaxSize}});
-decode_extensions(<<?UINT16(?CERTIFICATE_AUTHORITIES_EXT), ?UINT16(Len), 
+decode_extensions(<<?UINT16(?CERTIFICATE_AUTHORITIES_EXT), ?UINT16(Len),
                     CertAutsExt:Len/binary, Rest/binary>>,
                   Version, MessageType, Acc) ->
     CertAutsLen = Len - 2,
@@ -3350,7 +3418,7 @@ filter_hashsigns([], [], _, _, Acc) ->
 filter_hashsigns([Suite | Suites], [#{key_exchange := KeyExchange} | Algos], HashSigns, Version,
  		 Acc) when KeyExchange == dhe_ecdsa;
  			   KeyExchange == ecdhe_ecdsa ->
-    do_filter_hashsigns(ecdsa, Suite, Suites, Algos, HashSigns, Version, Acc); 
+    do_filter_hashsigns(ecdsa, Suite, Suites, Algos, HashSigns, Version, Acc);
 filter_hashsigns([Suite | Suites], [#{key_exchange := KeyExchange} | Algos], HashSigns, Version,
 		 Acc) when KeyExchange == rsa;
 			   KeyExchange == dhe_rsa;
@@ -3358,23 +3426,23 @@ filter_hashsigns([Suite | Suites], [#{key_exchange := KeyExchange} | Algos], Has
 			   KeyExchange == srp_rsa;
 			   KeyExchange == rsa_psk ->
     do_filter_hashsigns(rsa, Suite, Suites, Algos, HashSigns, Version, Acc);
-filter_hashsigns([Suite | Suites], [#{key_exchange := KeyExchange} | Algos], HashSigns, Version, Acc) when 
+filter_hashsigns([Suite | Suites], [#{key_exchange := KeyExchange} | Algos], HashSigns, Version, Acc) when
       KeyExchange == dhe_dss;
-      KeyExchange == srp_dss ->							       
+      KeyExchange == srp_dss ->
     do_filter_hashsigns(dsa, Suite, Suites, Algos, HashSigns, Version, Acc);
 filter_hashsigns([Suite | Suites], [#{key_exchange := KeyExchange} | Algos], HashSigns, Version,
-                 Acc) when 
-      KeyExchange == dh_dss; 
-      KeyExchange == dh_rsa; 
+                 Acc) when
+      KeyExchange == dh_dss;
+      KeyExchange == dh_rsa;
       KeyExchange == dh_ecdsa;
-      KeyExchange == ecdh_rsa;    
+      KeyExchange == ecdh_rsa;
       KeyExchange == ecdh_ecdsa ->
       %%  Fixed DH certificates MAY be signed with any hash/signature
       %%  algorithm pair appearing in the hash_sign extension.  The names
     %%  DH_DSS, DH_RSA, ECDH_ECDSA, and ECDH_RSA are historical.
     filter_hashsigns(Suites, Algos, HashSigns, Version, [Suite| Acc]);
 filter_hashsigns([Suite | Suites], [#{key_exchange := KeyExchange} | Algos], HashSigns, Version,
-                 Acc) when 
+                 Acc) when
       KeyExchange == dh_anon;
       KeyExchange == ecdh_anon;
       KeyExchange == srp_anon;
@@ -3402,20 +3470,20 @@ do_filter_hashsigns(SignAlgo, Suite, Suites, Algos, HashSigns, Version, Acc) ->
     end.
 
 filter_unavailable_ecc_suites(no_curve, Suites) ->
-    ECCSuites = ssl_cipher:filter_suites(Suites, #{key_exchange_filters => [fun(ecdh_ecdsa) -> true; 
-                                                                               (ecdhe_ecdsa) -> true; 
-                                                                               (ecdh_rsa) -> true; 
-                                                                               (_) -> false 
+    ECCSuites = ssl_cipher:filter_suites(Suites, #{key_exchange_filters => [fun(ecdh_ecdsa) -> true;
+                                                                               (ecdhe_ecdsa) -> true;
+                                                                               (ecdh_rsa) -> true;
+                                                                               (_) -> false
                                                                             end],
                                                    cipher_filters => [],
                                                    mac_filters => [],
                                                    prf_filters => []}),
-    Suites -- ECCSuites;       
+    Suites -- ECCSuites;
 filter_unavailable_ecc_suites(_, Suites) ->
     Suites.
 %%-------------Extension handling --------------------------------
 
-handle_renegotiation_extension(Role, RecordCB, Version, Info, Random, NegotiatedCipherSuite, 
+handle_renegotiation_extension(Role, RecordCB, Version, Info, Random, NegotiatedCipherSuite,
 			       ClientCipherSuites, Compression,
 			       ConnectionStates0, Renegotiation, SecureRenegotation) ->
     {ok, ConnectionStates} = handle_renegotiation_info(Version, RecordCB, Role, Info, ConnectionStates0,
@@ -3759,11 +3827,11 @@ cert_curve(_, _, no_suite) ->
     {no_curve, no_suite};
 cert_curve(Cert, ECCCurve0, CipherSuite) ->
     case ssl_cipher_format:suite_bin_to_map(CipherSuite) of
-        #{key_exchange := Kex} when Kex == ecdh_ecdsa; 
+        #{key_exchange := Kex} when Kex == ecdh_ecdsa;
                                     Kex == ecdh_rsa ->
             OtpCert = public_key:pkix_decode_cert(Cert, otp),
             TBSCert = OtpCert#'OTPCertificate'.tbsCertificate,
-            #'OTPSubjectPublicKeyInfo'{algorithm = AlgInfo} 
+            #'OTPSubjectPublicKeyInfo'{algorithm = AlgInfo}
                 = TBSCert#'OTPTBSCertificate'.subjectPublicKeyInfo,
             {namedCurve, Oid}  = AlgInfo#'PublicKeyAlgorithm'.parameters,
             {{namedCurve, Oid}, CipherSuite};
@@ -3875,11 +3943,11 @@ path_validation(TrustedCert, Path, ServerName, Role, CertDbHandle, CertDbRef, CR
                   log_level := Level,
                   signature_algs := SignAlgos,
                   signature_algs_cert := SignAlgosCert,
-                  depth := Depth}, 
+                  depth := Depth},
                 #{cert_ext := CertExt,
                   ocsp_responder_certs := OcspResponderCerts,
                   ocsp_state := OcspState}) ->
-    ValidationFunAndState = 
+    ValidationFunAndState =
         validation_fun_and_state(VerifyFun, #{role => Role,
                                               certdb => CertDbHandle,
                                               certdb_ref => CertDbRef,

--- a/lib/ssl/src/ssl_internal.hrl
+++ b/lib/ssl/src/ssl_internal.hrl
@@ -23,7 +23,7 @@
 -ifndef(ssl_internal).
 -define(ssl_internal, true).
 
--include_lib("public_key/include/public_key.hrl"). 
+-include_lib("public_key/include/public_key.hrl").
 
 -define(SECRET_PRINTOUT, "***").
 
@@ -65,7 +65,7 @@
 -define(NO_DIST_POINT, "http://dummy/no_distribution_point").
 -define(NO_DIST_POINT_PATH, "dummy/no_distribution_point").
 
-%% Common enumerate values in for SSL-protocols 
+%% Common enumerate values in for SSL-protocols
 -define(NULL, 0).
 -define(TRUE, 0).
 -define(FALSE, 1).
@@ -135,6 +135,7 @@
           certs_keys                 => {undefined, [versions]},
           certfile                   => {<<>>,      [versions]},
           certificate_authorities    => {false,     [versions]},
+          certificate_status         => {undefined, []},
           ciphers                    => {[],        [versions]},
           client_renegotiation       => {undefined, [versions]},
           cookie                     => {true,      [versions]},
@@ -227,7 +228,7 @@
 
 -record(socket_options,
 	{
-	  mode   = list, 
+	  mode   = list,
 	  packet = 0,
 	  packet_size = 0,
 	  header = 0,
@@ -236,8 +237,8 @@
 
 -record(config, {ssl,               %% SSL parameters
 		 inet_user,         %% User set inet options
-		 emulated,          %% Emulated option list or 
-                 trackers, 
+		 emulated,          %% Emulated option list or
+                 trackers,
 		 dtls_handler,
 		 inet_ssl,          %% inet options for internal ssl socket
 		 transport_info,                 %% Callback info
@@ -263,8 +264,3 @@
 
 
 -endif. % -ifdef(ssl_internal).
-
-
-
-
-

--- a/lib/ssl/src/tls_dtls_connection.erl
+++ b/lib/ssl/src/tls_dtls_connection.erl
@@ -105,14 +105,14 @@ prf(ConnectionPid, Secret, Label, Seed, WantedLength) ->
 			    gen_statem:state_function_result().
 %%--------------------------------------------------------------------
 handle_session(#server_hello{cipher_suite = CipherSuite,
-			     compression_method = Compression}, 
+			     compression_method = Compression},
 	       Version, NewId, ConnectionStates, ProtoExt, Protocol0,
 	       #state{session = #session{session_id = OldId},
 		      handshake_env = #handshake_env{negotiated_protocol = CurrentProtocol} = HsEnv,
                       connection_env = #connection_env{negotiated_version = ReqVersion} = CEnv} = State0) ->
     #{key_exchange := KeyAlgorithm} =
 	ssl_cipher_format:suite_bin_to_map(CipherSuite),
-    
+
     PremasterSecret = make_premaster_secret(ReqVersion, KeyAlgorithm),
 
     {ExpectNPN, Protocol} =
@@ -127,7 +127,7 @@ handle_session(#server_hello{cipher_suite = CipherSuite,
                                                              expecting_next_protocol_negotiation = ExpectNPN,
                                                              negotiated_protocol = Protocol},
                          connection_env = CEnv#connection_env{negotiated_version = Version}},
-    
+
     case ssl_session:is_new(OldId, NewId) of
 	true ->
 	    handle_new_session(NewId, CipherSuite, Compression,
@@ -140,7 +140,7 @@ handle_session(#server_hello{cipher_suite = CipherSuite,
 
 %%====================================================================
 %% gen_statem general state functions with connection cb argument
-%%====================================================================	
+%%====================================================================
 
 %%--------------------------------------------------------------------
 -spec hello(gen_statem:event_type(),
@@ -172,7 +172,7 @@ user_hello({call, From}, {handshake_continue, NewOptions, Timeout},
                   ssl_options = Options0} = State0) ->
     Options = ssl:handle_options(NewOptions, Role, Options0#{handshake => full}),
     State = ssl_gen_statem:ssl_config(Options, Role, State0),
-    {next_state, hello, State#state{start_or_recv_from = From}, 
+    {next_state, hello, State#state{start_or_recv_from = From},
      [{next_event, internal, Hello}, {{timeout, handshake}, Timeout, close}]};
 user_hello(info, {'DOWN', _, _, _, _} = Event, State) ->
     ssl_gen_statem:handle_info(Event, ?FUNCTION_NAME, State);
@@ -239,18 +239,18 @@ abbreviated(internal, #next_protocol{selected_protocol = SelectedProtocol},
 	    #state{static_env = #static_env{role = server,
                                             protocol_cb = Connection},
                    handshake_env = #handshake_env{expecting_next_protocol_negotiation = true} = HsEnv} = State) ->
-    Connection:next_event(?FUNCTION_NAME, no_record, 
+    Connection:next_event(?FUNCTION_NAME, no_record,
 			  State#state{handshake_env = HsEnv#handshake_env{negotiated_protocol = SelectedProtocol,
                                                                          expecting_next_protocol_negotiation = false}});
-abbreviated(internal, 
-	    #change_cipher_spec{type = <<1>>},  
+abbreviated(internal,
+	    #change_cipher_spec{type = <<1>>},
             #state{static_env = #static_env{protocol_cb = Connection},
                    connection_states = ConnectionStates0,
                    handshake_env = HsEnv} = State) ->
     ConnectionStates1 =
 	ssl_record:activate_pending_connection_state(ConnectionStates0, read, Connection),
-    Connection:next_event(?FUNCTION_NAME, no_record, State#state{connection_states = 
-                                                                     ConnectionStates1,                                                   
+    Connection:next_event(?FUNCTION_NAME, no_record, State#state{connection_states =
+                                                                     ConnectionStates1,
                                                                  handshake_env = HsEnv#handshake_env{expecting_finished = true}});
 abbreviated(info, Msg, State) ->
     handle_info(Msg, ?FUNCTION_NAME, State);
@@ -357,20 +357,20 @@ certify(internal, #server_key_exchange{exchange_keys = Keys},
                connection_env = #connection_env{negotiated_version = Version},
                session = Session,
 	       connection_states = ConnectionStates} = State)
-  when KexAlg == dhe_dss; 
+  when KexAlg == dhe_dss;
        KexAlg == dhe_rsa;
-       KexAlg == ecdhe_rsa; 
+       KexAlg == ecdhe_rsa;
        KexAlg == ecdhe_ecdsa;
-       KexAlg == dh_anon; 
+       KexAlg == dh_anon;
        KexAlg == ecdh_anon;
-       KexAlg == psk; 
-       KexAlg == dhe_psk; 
-       KexAlg == ecdhe_psk; 
+       KexAlg == psk;
+       KexAlg == dhe_psk;
+       KexAlg == ecdhe_psk;
        KexAlg == rsa_psk;
-       KexAlg == srp_dss; 
-       KexAlg == srp_rsa; 
+       KexAlg == srp_dss;
+       KexAlg == srp_rsa;
        KexAlg == srp_anon ->
-    
+
     Params = ssl_handshake:decode_server_key(Keys, KexAlg, ssl:tls_version(Version)),
 
     %% Use negotiated value if TLS-1.2 otherwise return default
@@ -381,7 +381,7 @@ certify(internal, #server_key_exchange{exchange_keys = Keys},
 	    calculate_secret(Params#server_key_params.params,
 			     State#state{handshake_env = HsEnv#handshake_env{hashsign_algorithm = HashSign}}, Connection);
 	false ->
-	    case  ssl_handshake:verify_server_key(Params, HashSign, 
+	    case  ssl_handshake:verify_server_key(Params, HashSign,
 						  ConnectionStates, ssl:tls_version(Version), PubKeyInfo) of
 		true ->
 		    calculate_secret(Params#server_key_params.params,
@@ -395,14 +395,14 @@ certify(internal, #server_key_exchange{exchange_keys = Keys},
 certify(internal, #certificate_request{},
 	#state{static_env = #static_env{role = client},
                handshake_env = #handshake_env{kex_algorithm = KexAlg}})
-  when KexAlg == dh_anon; 
+  when KexAlg == dh_anon;
        KexAlg == ecdh_anon;
-       KexAlg == psk; 
-       KexAlg == dhe_psk; 
-       KexAlg == ecdhe_psk; 
+       KexAlg == psk;
+       KexAlg == dhe_psk;
+       KexAlg == ecdhe_psk;
        KexAlg == rsa_psk;
-       KexAlg == srp_dss; 
-       KexAlg == srp_rsa; 
+       KexAlg == srp_dss;
+       KexAlg == srp_rsa;
        KexAlg == srp_anon ->
     throw(?ALERT_REC(?FATAL, ?HANDSHAKE_FAILURE));
 certify(internal, #certificate_request{},
@@ -410,7 +410,7 @@ certify(internal, #certificate_request{},
                                         protocol_cb = Connection},
                session = Session0,
                connection_env = #connection_env{cert_key_alts = [#{certs := [[]]}]}} = State) ->
-    %% The client does not have a certificate and will send an empty reply, the server may fail 
+    %% The client does not have a certificate and will send an empty reply, the server may fail
     %% or accept the connection by its own preference. No signature algorithms needed as there is
     %% no certificate to verify.
     Connection:next_event(?FUNCTION_NAME, no_record, State#state{client_certificate_requested = true,
@@ -465,18 +465,18 @@ certify(internal, #server_hello_done{},
   when KexAlg == rsa_psk ->
     Rand = ssl_cipher:random_bytes(?NUM_OF_PREMASTERSECRET_BYTES-2),
     RSAPremasterSecret = <<?BYTE(Major), ?BYTE(Minor), Rand/binary>>,
-    case ssl_handshake:premaster_secret({KexAlg, PSKIdentity}, PSKLookup, 
+    case ssl_handshake:premaster_secret({KexAlg, PSKIdentity}, PSKLookup,
 					RSAPremasterSecret) of
 	#alert{} = Alert ->
             throw(Alert);
 	PremasterSecret ->
-	    State = master_secret(PremasterSecret, 
-				  State0#state{handshake_env = 
+	    State = master_secret(PremasterSecret,
+				  State0#state{handshake_env =
                                                    HsEnv#handshake_env{premaster_secret = RSAPremasterSecret}}),
 	    client_certify_and_key_exchange(State, Connection)
     end;
 %% Master secret was determined with help of server-key exchange msg
-certify(internal, #server_hello_done{}, 
+certify(internal, #server_hello_done{},
 	#state{static_env = #static_env{role = client,
                                         protocol_cb = Connection},
                connection_env = #connection_env{negotiated_version = Version},
@@ -516,7 +516,7 @@ certify(internal = Type, #client_key_exchange{} = Msg,
     %% We expect a certificate here
     throw(?ALERT_REC(?FATAL,?UNEXPECTED_MESSAGE, {unexpected_msg, {Type, Msg}}));
 certify(internal, #client_key_exchange{exchange_keys = Keys},
-	State = #state{handshake_env = #handshake_env{kex_algorithm = KeyAlg}, 
+	State = #state{handshake_env = #handshake_env{kex_algorithm = KeyAlg},
                        static_env = #static_env{protocol_cb = Connection},
                        connection_env = #connection_env{negotiated_version = Version}}) ->
     try
@@ -530,7 +530,7 @@ certify(internal, #hello_request{}, _) ->
     keep_state_and_data;
 certify(Type, Event, State) ->
     ssl_gen_statem:handle_common_event(Type, Event, ?FUNCTION_NAME, State).
- 
+
 %%--------------------------------------------------------------------
 -spec cipher(gen_statem:event_type(),
 	     #hello_request{} | #certificate_verify{} | #finished{} | term(),
@@ -541,7 +541,7 @@ cipher({call, From}, Msg, State) ->
     handle_call(Msg, From, ?FUNCTION_NAME, State);
 cipher(info, Msg, State) ->
     handle_info(Msg, ?FUNCTION_NAME, State);
-cipher(internal, #certificate_verify{signature = Signature, 
+cipher(internal, #certificate_verify{signature = Signature,
 				     hashsign_algorithm = CertHashSign},
        #state{static_env = #static_env{role = server,
                                        protocol_cb = Connection},
@@ -551,7 +551,7 @@ cipher(internal, #certificate_verify{signature = Signature,
               connection_env = #connection_env{negotiated_version = Version},
 	      session = #session{master_secret = MasterSecret} = Session0
 	     } = State) ->
-    
+
     TLSVersion = ssl:tls_version(Version),
     %% Use negotiated value if TLS-1.2 otherwise return default
     HashSign = negotiated_hashsign(CertHashSign, KexAlg, PubKeyInfo, TLSVersion),
@@ -613,16 +613,16 @@ cipher(internal, #hello_request{}, _) ->
     keep_state_and_data;
 cipher(Type, Event, State) ->
     ssl_gen_statem:handle_common_event(Type, Event, ?FUNCTION_NAME, State).
- 
+
 %%--------------------------------------------------------------------
 -spec connection(gen_statem:event_type(), term(), #state{}) ->
 			gen_statem:state_function_result().
 %%--------------------------------------------------------------------
 connection({call, From}, renegotiate, #state{static_env = #static_env{protocol_cb = tls_gen_connection},
-                                             handshake_env = HsEnv} = State) -> 
+                                             handshake_env = HsEnv} = State) ->
     tls_connection:renegotiate(State#state{handshake_env = HsEnv#handshake_env{renegotiation = {true, From}}}, []);
 connection({call, From}, renegotiate, #state{static_env = #static_env{protocol_cb = dtls_gen_connection},
-                                             handshake_env = HsEnv} = State) -> 
+                                             handshake_env = HsEnv} = State) ->
     dtls_connection:renegotiate(State#state{handshake_env = HsEnv#handshake_env{renegotiation = {true, From}}}, []);
 connection({call, From}, negotiated_protocol,
 	   #state{handshake_env = #handshake_env{alpn = undefined,
@@ -723,12 +723,19 @@ do_server_hello(Type, #{next_protocol_negotiation := NextProtocols} =
                        handshake_env = HsEnv,
 		       session = #session{session_id = SessId},
 		       connection_states = ConnectionStates0,
-                       ssl_options = #{versions := [HighestVersion|_]}}
+                       ssl_options = #{versions := [HighestVersion|_]} = SSLOpts0}
 		= State0) when is_atom(Type) ->
     %% TLS 1.3 - Section 4.1.3
     %% Override server random values for TLS 1.3 downgrade protection mechanism.
     ConnectionStates1 = update_server_random(ConnectionStates0, Version, HighestVersion),
-    State1 = State0#state{connection_states = ConnectionStates1},
+    SSLOpts1 = case {SSLOpts0, ServerHelloExt} of
+                   { #{certificate_status := #certificate_status{}}
+                   , #{status_request := #certificate_status_request{}}
+                   } -> SSLOpts0;
+                   _ -> SSLOpts0#{certificate_status => undefined}
+               end,
+    State1 = State0#state{connection_states = ConnectionStates1,
+                          ssl_options = SSLOpts1},
     ServerHello =
 	ssl_handshake:server_hello(SessId, ssl:tls_version(Version),
                                    ConnectionStates1, ServerHelloExt),
@@ -904,8 +911,30 @@ do_client_certify_and_key_exchange(State0, Connection) ->
 
 server_certify_and_key_exchange(State0, Connection) ->
     State1 = certify_server(State0, Connection),
-    State2 = key_exchange(State1, Connection),
-    request_client_cert(State2, Connection).
+    io:format(user, "~n~n~p:~p:~p >>>>>>>>>>>>>>>>>>>>>>:~n ~p~n~n",
+              [?MODULE, ?FUNCTION_NAME, ?LINE,
+               #{ state0 => State0
+                , conn => Connection
+                }]),
+    State2 = certificate_status(State1, Connection),
+    State3 = key_exchange(State2, Connection),
+    request_client_cert(State3, Connection).
+
+certificate_status(#state{ssl_options = SSLOpts = #{certificate_status := undefined}} = State, _) ->
+        io:format(user, "~n~n~p:~p:~p >>>>>>>>>>>>>>>>>>>>>> status undefined~n  ~p~n~n",
+              [?MODULE, ?FUNCTION_NAME, ?LINE, SSLOpts]),
+    State;
+certificate_status(#state{ssl_options = #{certificate_status := #certificate_status{} = Status}} = State, Connection) ->
+    io:format(user, "~n~n~p:~p:~p >>>>>>>>>>>>>>>>>>>>>> some status ~n  ~p~n~n",
+              [?MODULE, ?FUNCTION_NAME, ?LINE,
+               #{ state => State
+                , conn => Connection
+                }]),
+    Connection:queue_handshake(Status, State);
+certificate_status(State, _) ->
+    io:format(user, "~n~n~p:~p:~p >>>>>>>>>>>>>>>>>>>>>> argh, state:~n ~100p~n~n",
+              [?MODULE, ?FUNCTION_NAME, ?LINE, State]),
+    State.
 
 certify_client_key_exchange(#encrypted_premaster_secret{premaster_secret= EncPMS},
 			    #state{session = #session{private_key = PrivateKey},
@@ -943,7 +972,7 @@ certify_client_key_exchange(#client_ec_diffie_hellman_public{dh_public = ClientP
     PremasterSecret = ssl_handshake:premaster_secret(#'ECPoint'{point = ClientPublicEcDhPoint}, ECDHKey),
     calculate_master_secret(PremasterSecret, State, Connection, certify, cipher);
 certify_client_key_exchange(#client_psk_identity{} = ClientKey,
-			    #state{ssl_options = 
+			    #state{ssl_options =
 				       #{user_lookup_fun := PSKLookup}} = State0,
 			    Connection) ->
     PremasterSecret = ssl_handshake:premaster_secret(ClientKey, PSKLookup),
@@ -951,10 +980,10 @@ certify_client_key_exchange(#client_psk_identity{} = ClientKey,
 certify_client_key_exchange(#client_dhe_psk_identity{} = ClientKey,
 			    #state{handshake_env = #handshake_env{diffie_hellman_params = #'DHParameter'{} = Params,
                                                                   kex_keys = {_, ServerDhPrivateKey}},
-				   ssl_options = 
+				   ssl_options =
 				       #{user_lookup_fun := PSKLookup}} = State0,
 			    Connection) ->
-    PremasterSecret = 
+    PremasterSecret =
 	ssl_handshake:premaster_secret(ClientKey, ServerDhPrivateKey, Params, PSKLookup),
     calculate_master_secret(PremasterSecret, State0, Connection, certify, cipher);
 certify_client_key_exchange(#client_ecdhe_psk_identity{} = ClientKey,
@@ -967,7 +996,7 @@ certify_client_key_exchange(#client_ecdhe_psk_identity{} = ClientKey,
     calculate_master_secret(PremasterSecret, State, Connection, certify, cipher);
 certify_client_key_exchange(#client_rsa_psk_identity{} = ClientKey,
 			    #state{session = #session{private_key = PrivateKey},
-				   ssl_options = 
+				   ssl_options =
 				       #{user_lookup_fun := PSKLookup}} = State0,
 			    Connection) ->
     PremasterSecret = ssl_handshake:premaster_secret(ClientKey, PrivateKey, PSKLookup),
@@ -979,12 +1008,12 @@ certify_client_key_exchange(#client_srp_public{} = ClientKey,
     PremasterSecret = ssl_handshake:premaster_secret(ClientKey, Key, Params),
     calculate_master_secret(PremasterSecret, State0, Connection, certify, cipher).
 
-certify_server(#state{handshake_env = #handshake_env{kex_algorithm = KexAlg}} = 
-                   State, _) when KexAlg == dh_anon; 
-                                  KexAlg == ecdh_anon; 
-                                  KexAlg == psk; 
-                                  KexAlg == dhe_psk; 
-                                  KexAlg == ecdhe_psk; 
+certify_server(#state{handshake_env = #handshake_env{kex_algorithm = KexAlg}} =
+                   State, _) when KexAlg == dh_anon;
+                                  KexAlg == ecdh_anon;
+                                  KexAlg == psk;
+                                  KexAlg == dhe_psk;
+                                  KexAlg == ecdhe_psk;
                                   KexAlg == srp_anon  ->
     State;
 certify_server(#state{static_env = #static_env{cert_db = CertDbHandle,
@@ -994,10 +1023,10 @@ certify_server(#state{static_env = #static_env{cert_db = CertDbHandle,
     #certificate{} = Cert,  %% Assert
     Connection:queue_handshake(Cert, State).
 
-key_exchange(#state{static_env = #static_env{role = server}, 
+key_exchange(#state{static_env = #static_env{role = server},
                     handshake_env = #handshake_env{kex_algorithm = rsa}} = State,_) ->
     State;
-key_exchange(#state{static_env = #static_env{role = server}, 
+key_exchange(#state{static_env = #static_env{role = server},
 		    handshake_env = #handshake_env{kex_algorithm = KexAlg,
                                                    diffie_hellman_params = #'DHParameter'{} = Params,
                                                    hashsign_algorithm = HashSignAlgo},
@@ -1021,58 +1050,58 @@ key_exchange(#state{static_env = #static_env{role = server},
 key_exchange(#state{static_env = #static_env{role = server},
                     handshake_env = #handshake_env{kex_algorithm = KexAlg} = HsEnv,
                     session = #session{private_key = #'ECPrivateKey'{parameters = ECCurve} = Key} = Session} = State, _)
-  when KexAlg == ecdh_ecdsa; 
+  when KexAlg == ecdh_ecdsa;
        KexAlg == ecdh_rsa ->
     State#state{handshake_env = HsEnv#handshake_env{kex_keys = Key},
                 session = Session#session{ecc = ECCurve}};
-key_exchange(#state{static_env = #static_env{role = server}, 
+key_exchange(#state{static_env = #static_env{role = server},
                     handshake_env = #handshake_env{kex_algorithm = KexAlg,
                                                    hashsign_algorithm = HashSignAlgo},
                     connection_env = #connection_env{negotiated_version = Version},
 		    session = #session{ecc = ECCCurve, private_key = PrivateKey},
 		    connection_states = ConnectionStates0} = State0, Connection)
-  when KexAlg == ecdhe_ecdsa; 
+  when KexAlg == ecdhe_ecdsa;
        KexAlg == ecdhe_rsa;
        KexAlg == ecdh_anon ->
 
     ECDHKeys = public_key:generate_key(ECCCurve),
-    #{security_parameters := SecParams} = 
+    #{security_parameters := SecParams} =
 	ssl_record:pending_connection_state(ConnectionStates0, read),
     #security_parameters{client_random = ClientRandom,
 			 server_random = ServerRandom} = SecParams,
-    Msg =  ssl_handshake:key_exchange(server, ssl:tls_version(Version), 
+    Msg =  ssl_handshake:key_exchange(server, ssl:tls_version(Version),
 				      {ecdh, ECDHKeys,
 				       HashSignAlgo, ClientRandom,
 				       ServerRandom,
 				       PrivateKey}),
     #state{handshake_env = HsEnv} = State = Connection:queue_handshake(Msg, State0),
     State#state{handshake_env = HsEnv#handshake_env{kex_keys = ECDHKeys}};
-key_exchange(#state{static_env = #static_env{role = server}, 
+key_exchange(#state{static_env = #static_env{role = server},
                     handshake_env = #handshake_env{kex_algorithm = psk},
 		    ssl_options = #{psk_identity := undefined}} = State, _) ->
     State;
-key_exchange(#state{static_env = #static_env{role = server}, 
+key_exchange(#state{static_env = #static_env{role = server},
 		    ssl_options = #{psk_identity := PskIdentityHint},
 		    handshake_env = #handshake_env{kex_algorithm = psk,
-                                                   hashsign_algorithm = HashSignAlgo},     
+                                                   hashsign_algorithm = HashSignAlgo},
                     connection_env = #connection_env{negotiated_version = Version},
                     session = #session{private_key = PrivateKey},
                     connection_states = ConnectionStates0} = State0, Connection) ->
-    #{security_parameters := SecParams} = 
+    #{security_parameters := SecParams} =
 	ssl_record:pending_connection_state(ConnectionStates0, read),
     #security_parameters{client_random = ClientRandom,
 			 server_random = ServerRandom} = SecParams,
-    Msg = ssl_handshake:key_exchange(server, ssl:tls_version(Version), 
+    Msg = ssl_handshake:key_exchange(server, ssl:tls_version(Version),
 				     {psk, PskIdentityHint,
 				      HashSignAlgo, ClientRandom,
 				      ServerRandom,
                                       PrivateKey}),
     Connection:queue_handshake(Msg, State0);
-key_exchange(#state{static_env = #static_env{role = server},                    
+key_exchange(#state{static_env = #static_env{role = server},
 		    ssl_options = #{psk_identity := PskIdentityHint},
 		    handshake_env = #handshake_env{kex_algorithm = dhe_psk,
                                                    diffie_hellman_params = #'DHParameter'{} = Params,
-                                                   hashsign_algorithm = HashSignAlgo},                                        
+                                                   hashsign_algorithm = HashSignAlgo},
                     connection_env = #connection_env{negotiated_version = Version},
                     session = #session{private_key = PrivateKey},
 		    connection_states = ConnectionStates0
@@ -1082,15 +1111,15 @@ key_exchange(#state{static_env = #static_env{role = server},
 	ssl_record:pending_connection_state(ConnectionStates0, read),
     #security_parameters{client_random = ClientRandom,
 			 server_random = ServerRandom} = SecParams,
-    Msg =  ssl_handshake:key_exchange(server, ssl:tls_version(Version), 
-				      {dhe_psk, 
+    Msg =  ssl_handshake:key_exchange(server, ssl:tls_version(Version),
+				      {dhe_psk,
 				       PskIdentityHint, DHKeys, Params,
 				       HashSignAlgo, ClientRandom,
 				       ServerRandom,
 				       PrivateKey}),
     #state{handshake_env = HsEnv} = State = Connection:queue_handshake(Msg, State0),
     State#state{handshake_env = HsEnv#handshake_env{kex_keys = DHKeys}};
-key_exchange(#state{static_env = #static_env{role = server}, 
+key_exchange(#state{static_env = #static_env{role = server},
 		    ssl_options = #{psk_identity := PskIdentityHint},
                     handshake_env = #handshake_env{kex_algorithm = ecdhe_psk,
                                                    hashsign_algorithm = HashSignAlgo},
@@ -1111,14 +1140,14 @@ key_exchange(#state{static_env = #static_env{role = server},
 				       PrivateKey}),
     #state{handshake_env = HsEnv} = State = Connection:queue_handshake(Msg, State0),
     State#state{handshake_env = HsEnv#handshake_env{kex_keys = ECDHKeys}};
-key_exchange(#state{static_env = #static_env{role = server}, 
+key_exchange(#state{static_env = #static_env{role = server},
                     handshake_env = #handshake_env{kex_algorithm = rsa_psk},
 		    ssl_options = #{psk_identity := undefined}} = State, _) ->
     State;
-key_exchange(#state{static_env = #static_env{role = server}, 
+key_exchange(#state{static_env = #static_env{role = server},
 		    ssl_options = #{psk_identity := PskIdentityHint},
                     handshake_env = #handshake_env{kex_algorithm = rsa_psk,
-                                                   hashsign_algorithm = HashSignAlgo}, 
+                                                   hashsign_algorithm = HashSignAlgo},
                     connection_env = #connection_env{negotiated_version = Version},
                     session = #session{private_key = PrivateKey},
 		    connection_states = ConnectionStates0
@@ -1127,16 +1156,16 @@ key_exchange(#state{static_env = #static_env{role = server},
 	ssl_record:pending_connection_state(ConnectionStates0, read),
     #security_parameters{client_random = ClientRandom,
 			 server_random = ServerRandom} = SecParams,
-    Msg =  ssl_handshake:key_exchange(server, ssl:tls_version(Version), 
+    Msg =  ssl_handshake:key_exchange(server, ssl:tls_version(Version),
 				      {psk, PskIdentityHint,
 				       HashSignAlgo, ClientRandom,
 				       ServerRandom,
 				       PrivateKey}),
     Connection:queue_handshake(Msg, State0);
-key_exchange(#state{static_env = #static_env{role = server}, 
+key_exchange(#state{static_env = #static_env{role = server},
 		    ssl_options = #{user_lookup_fun := LookupFun},
                     handshake_env = #handshake_env{kex_algorithm = KexAlg,
-                                                   hashsign_algorithm = HashSignAlgo}, 
+                                                   hashsign_algorithm = HashSignAlgo},
                     connection_env = #connection_env{negotiated_version = Version},
 		    session = #session{srp_username = Username, private_key = PrivateKey},
 		    connection_states = ConnectionStates0
@@ -1183,9 +1212,9 @@ key_exchange(#state{static_env = #static_env{role = client},
                     connection_env = #connection_env{negotiated_version = Version},
                     session = Session
 		   } = State0, Connection)
-  when KexAlg == ecdhe_ecdsa; 
+  when KexAlg == ecdhe_ecdsa;
        KexAlg == ecdhe_rsa;
-       KexAlg == ecdh_ecdsa; 
+       KexAlg == ecdh_ecdsa;
        KexAlg == ecdh_rsa;
        KexAlg == ecdh_anon ->
     Msg = ssl_handshake:key_exchange(client, ssl:tls_version(Version), {ecdh, Key}),
@@ -1194,7 +1223,7 @@ key_exchange(#state{static_env = #static_env{role = client},
                     handshake_env = #handshake_env{kex_algorithm = psk},
                     connection_env = #connection_env{negotiated_version = Version},
 		    ssl_options = #{psk_identity := PSKIdentity}} = State0, Connection) ->
-    Msg =  ssl_handshake:key_exchange(client, ssl:tls_version(Version), 
+    Msg =  ssl_handshake:key_exchange(client, ssl:tls_version(Version),
 				      {psk, PSKIdentity}),
     Connection:queue_handshake(Msg, State0);
 key_exchange(#state{static_env = #static_env{role = client},
@@ -1203,7 +1232,7 @@ key_exchange(#state{static_env = #static_env{role = client},
                     connection_env = #connection_env{negotiated_version = Version},
 		    ssl_options = #{psk_identity := PSKIdentity}} = State0, Connection) ->
     Msg =  ssl_handshake:key_exchange(client, ssl:tls_version(Version),
-				      {dhe_psk, 
+				      {dhe_psk,
 				       PSKIdentity, DhPubKey}),
     Connection:queue_handshake(Msg, State0);
 
@@ -1254,7 +1283,7 @@ rsa_key_exchange(Version, PremasterSecret, PublicKeyInfo = {Algorithm, _, _})
 rsa_key_exchange(_, _, _) ->
     throw(?ALERT_REC(?FATAL,?HANDSHAKE_FAILURE, pub_key_is_not_rsa)).
 
-rsa_psk_key_exchange(Version, PskIdentity, PremasterSecret, 
+rsa_psk_key_exchange(Version, PskIdentity, PremasterSecret,
 		     PublicKeyInfo = {Algorithm, _, _})
   when Algorithm == ?rsaEncryption;
        Algorithm == ?md2WithRSAEncryption;
@@ -1272,14 +1301,14 @@ rsa_psk_key_exchange(_, _, _, _) ->
     throw(?ALERT_REC(?FATAL,?HANDSHAKE_FAILURE, pub_key_is_not_rsa)).
 
 request_client_cert(#state{handshake_env = #handshake_env{kex_algorithm = Alg}} = State, _)
-  when Alg == dh_anon; 
+  when Alg == dh_anon;
        Alg == ecdh_anon;
-       Alg == psk; 
-       Alg == dhe_psk; 
-       Alg == ecdhe_psk; 
+       Alg == psk;
+       Alg == dhe_psk;
+       Alg == ecdhe_psk;
        Alg == rsa_psk;
-       Alg == srp_dss; 
-       Alg == srp_rsa; 
+       Alg == srp_dss;
+       Alg == srp_rsa;
        Alg == srp_anon ->
     State;
 
@@ -1289,9 +1318,9 @@ request_client_cert(#state{static_env = #static_env{cert_db = CertDbHandle,
                            ssl_options = #{verify := verify_peer,
                                            signature_algs := SupportedHashSigns}} = State0, Connection) ->
     TLSVersion =  ssl:tls_version(Version),
-    HashSigns = ssl_handshake:available_signature_algs(SupportedHashSigns, 
+    HashSigns = ssl_handshake:available_signature_algs(SupportedHashSigns,
 						       TLSVersion),
-    Msg = ssl_handshake:certificate_request(CertDbHandle, CertDbRef, 
+    Msg = ssl_handshake:certificate_request(CertDbHandle, CertDbRef,
 					    HashSigns, TLSVersion),
     State = Connection:queue_handshake(Msg, State0),
     State#state{client_certificate_requested = true};
@@ -1300,7 +1329,7 @@ request_client_cert(#state{ssl_options = #{verify := verify_none}} =
 		    State, _) ->
     State.
 
-calculate_master_secret(PremasterSecret, 
+calculate_master_secret(PremasterSecret,
 			#state{connection_env = #connection_env{negotiated_version = Version},
 			       connection_states = ConnectionStates0,
 			       session = Session0} = State0, Connection,
@@ -1345,7 +1374,7 @@ finished(#state{static_env = #static_env{role = Role},
                 handshake_env = #handshake_env{tls_handshake_history = Hist},
                 connection_env = #connection_env{negotiated_version = Version},
 		session = Session,
-                connection_states = ConnectionStates0} = State0, 
+                connection_states = ConnectionStates0} = State0,
          StateName, Connection) ->
     MasterSecret = Session#session.master_secret,
     Finished = ssl_handshake:finished(ssl:tls_version(Version), Role,
@@ -1364,21 +1393,21 @@ save_verify_data(client, #finished{verify_data = Data}, ConnectionStates, abbrev
 save_verify_data(server, #finished{verify_data = Data}, ConnectionStates, abbreviated) ->
     ssl_record:set_server_verify_data(current_write, Data, ConnectionStates).
 
-calculate_secret(#server_dh_params{dh_p = Prime, dh_g = Base, 
+calculate_secret(#server_dh_params{dh_p = Prime, dh_g = Base,
 				   dh_y = ServerPublicDhKey} = Params,
 		 #state{handshake_env = HsEnv} = State, Connection) ->
     Keys = {_, PrivateDhKey} = crypto:generate_key(dh, [Prime, Base]),
     PremasterSecret =
 	ssl_handshake:premaster_secret(ServerPublicDhKey, PrivateDhKey, Params),
     calculate_master_secret(PremasterSecret,
-			    State#state{handshake_env = HsEnv#handshake_env{kex_keys = Keys}}, 
+			    State#state{handshake_env = HsEnv#handshake_env{kex_keys = Keys}},
 			    Connection, certify, certify);
 
 calculate_secret(#server_ecdh_params{curve = ECCurve, public = ECServerPubKey},
 		     #state{handshake_env = HsEnv,
                             session = Session} = State, Connection) ->
     ECDHKeys = public_key:generate_key(ECCurve),
-    PremasterSecret = 
+    PremasterSecret =
 	ssl_handshake:premaster_secret(#'ECPoint'{point = ECServerPubKey}, ECDHKeys),
     calculate_master_secret(PremasterSecret,
 			    State#state{handshake_env = HsEnv#handshake_env{kex_keys = ECDHKeys},
@@ -1389,8 +1418,8 @@ calculate_secret(#server_psk_params{
 		    hint = IdentityHint},
 		 #state{handshake_env = HsEnv} = State, Connection) ->
     %% store for later use
-    Connection:next_event(certify, no_record, 
-                          State#state{handshake_env = 
+    Connection:next_event(certify, no_record,
+                          State#state{handshake_env =
                                           HsEnv#handshake_env{server_psk_identity = IdentityHint}});
 
 calculate_secret(#server_dhe_psk_params{
@@ -1423,7 +1452,7 @@ calculate_secret(#server_srp_params{srp_n = Prime, srp_g = Generator} = ServerKe
 		 Connection) ->
     Keys = generate_srp_client_keys(Generator, Prime, 0),
     PremasterSecret = ssl_handshake:premaster_secret(ServerKey, Keys, SRPId),
-    calculate_master_secret(PremasterSecret, State#state{handshake_env = HsEnv#handshake_env{kex_keys = Keys}}, Connection, 
+    calculate_master_secret(PremasterSecret, State#state{handshake_env = HsEnv#handshake_env{kex_keys = Keys}}, Connection,
 			    certify, certify).
 
 master_secret(#alert{} = Alert, _) ->
@@ -1484,7 +1513,7 @@ handle_srp_identity(Username, {Fun, UserState}) ->
 
 cipher_role(client, Data, Session, #state{static_env = #static_env{protocol_cb = Connection},
                                           connection_states = ConnectionStates0} = State0) ->
-    ConnectionStates = ssl_record:set_server_verify_data(current_both, Data, 
+    ConnectionStates = ssl_record:set_server_verify_data(current_both, Data,
 							 ConnectionStates0),
     {Record, State} = ssl_gen_statem:prepare_connection(State0#state{session = Session,
                                                                          connection_states = ConnectionStates},
@@ -1492,7 +1521,7 @@ cipher_role(client, Data, Session, #state{static_env = #static_env{protocol_cb =
     Connection:next_event(connection, Record, State, [{{timeout, handshake}, infinity, close}]);
 cipher_role(server, Data, Session,  #state{static_env = #static_env{protocol_cb = Connection},
                                        connection_states = ConnectionStates0} = State0) ->
-    ConnectionStates1 = ssl_record:set_client_verify_data(current_read, Data, 
+    ConnectionStates1 = ssl_record:set_client_verify_data(current_read, Data,
 							  ConnectionStates0),
     {State1, Actions} =
 	finalize_handshake(State0#state{connection_states = ConnectionStates1,
@@ -1530,14 +1559,14 @@ session_handle_params(#server_ecdh_params{curve = ECCurve}, Session) ->
 session_handle_params(_, Session) ->
     Session.
 
-handle_session(server, #{reuse_sessions := true}, 
+handle_session(server, #{reuse_sessions := true},
                _Host, _Port, Trackers, #session{is_resumable = false} = Session) ->
     Tracker = proplists:get_value(session_id_tracker, Trackers),
     server_register_session(Tracker, Session#session{is_resumable = true});
 handle_session(Role = client, #{verify := verify_peer,
                                 reuse_sessions := Reuse} = SslOpts,
                Host, Port, _, #session{is_resumable = false} = Session) when Reuse =/= false ->
-    client_register_session(host_id(Role, Host, SslOpts), Port, Session#session{is_resumable = true}, 
+    client_register_session(host_id(Role, Host, SslOpts), Port, Session#session{is_resumable = true},
                             reg_type(Reuse));
 handle_session(_,_,_,_,_, Session) ->
     Session.
@@ -1559,7 +1588,7 @@ host_id(client, _Host, #{server_name_indication := Hostname}) when is_list(Hostn
 host_id(_, Host, _) ->
     Host.
 
-handle_new_session(NewId, CipherSuite, Compression, 
+handle_new_session(NewId, CipherSuite, Compression,
 		   #state{static_env = #static_env{protocol_cb = Connection},
                           session = Session0
 			 } = State0) ->
@@ -1601,7 +1630,7 @@ make_premaster_secret(_, _) ->
     undefined.
 
 negotiated_hashsign(undefined, KexAlg, PubKeyInfo, Version) ->
-    %% Not negotiated choose default 
+    %% Not negotiated choose default
     case is_anonymous(KexAlg) of
 	true ->
 	    {null, anon};
@@ -1624,12 +1653,12 @@ handle_sni_extension(#state{static_env =
             throw(Alert)
     end.
 
-ensure_tls({254, _} = Version) -> 
+ensure_tls({254, _} = Version) ->
     dtls_v1:corresponding_tls_version(Version);
-ensure_tls(Version) -> 
+ensure_tls(Version) ->
     Version.
 
-ocsp_info(#{ocsp_expect := stapled, 
+ocsp_info(#{ocsp_expect := stapled,
             ocsp_response := CertStatus} = OcspState,
             #{ocsp_responder_certs := OcspResponderCerts}, PeerCert) ->
     #{cert_ext => #{public_key:pkix_subject_id(PeerCert) => [CertStatus]},

--- a/lib/ssl/src/tls_dtls_connection.erl
+++ b/lib/ssl/src/tls_dtls_connection.erl
@@ -911,29 +911,13 @@ do_client_certify_and_key_exchange(State0, Connection) ->
 
 server_certify_and_key_exchange(State0, Connection) ->
     State1 = certify_server(State0, Connection),
-    io:format(user, "~n~n~p:~p:~p >>>>>>>>>>>>>>>>>>>>>>:~n ~p~n~n",
-              [?MODULE, ?FUNCTION_NAME, ?LINE,
-               #{ state0 => State0
-                , conn => Connection
-                }]),
     State2 = certificate_status(State1, Connection),
     State3 = key_exchange(State2, Connection),
     request_client_cert(State3, Connection).
 
-certificate_status(#state{ssl_options = SSLOpts = #{certificate_status := undefined}} = State, _) ->
-        io:format(user, "~n~n~p:~p:~p >>>>>>>>>>>>>>>>>>>>>> status undefined~n  ~p~n~n",
-              [?MODULE, ?FUNCTION_NAME, ?LINE, SSLOpts]),
-    State;
 certificate_status(#state{ssl_options = #{certificate_status := #certificate_status{} = Status}} = State, Connection) ->
-    io:format(user, "~n~n~p:~p:~p >>>>>>>>>>>>>>>>>>>>>> some status ~n  ~p~n~n",
-              [?MODULE, ?FUNCTION_NAME, ?LINE,
-               #{ state => State
-                , conn => Connection
-                }]),
     Connection:queue_handshake(Status, State);
 certificate_status(State, _) ->
-    io:format(user, "~n~n~p:~p:~p >>>>>>>>>>>>>>>>>>>>>> argh, state:~n ~100p~n~n",
-              [?MODULE, ?FUNCTION_NAME, ?LINE, State]),
     State.
 
 certify_client_key_exchange(#encrypted_premaster_secret{premaster_secret= EncPMS},


### PR DESCRIPTION
I used [this branch](https://github.com/thalesmg/tls-scripts/tree/ocsp-tests) to generate certificates.

```sh
  openssl ocsp \
        -CApath /home/thales/dev/emqx/tls-scripts/ \
        -index /home/thales/dev/emqx/tls-scripts/ca/index.txt \
        -port 9877 \
        -rkey /home/thales/dev/emqx/tls-scripts/inter-ca.key \
        -rsigner /home/thales/dev/emqx/tls-scripts/inter-ca.pem \
        -CA /home/thales/dev/emqx/tls-scripts/ca.pem \
        -text

  ## generate a request (or even the response with -respout
  openssl ocsp -CAfile /home/thales/dev/emqx/tls-scripts/merged-ca.pem \
        -resp_text \
        -no_nonce \
        -reqout /tmp/ocsp3.req \
        -respout /tmp/ocsp3.resp \
        -issuer /home/thales/dev/emqx/tls-scripts/inter-ca.pem \
        -cert /home/thales/dev/emqx/tls-scripts/server.pem

  openssl enc \
        -in /tmp/ocsp3.req \
        -out /tmp/ocsp3.req.b64 \
        -a -A
```

```erlang
%% make the request or read a ready response in the sni_fun callback
%% the client needs to present the SNI option during connection
SNIFun =
  fun(ServerName) ->
          {ok, Resp} = file:read_file("/tmp/ocsp3.resp"),
          [ {certificate_status, #certificate_status{
                                    status_type = 1,
                                    response = Resp
                                   }}
          ]
  end.

%% or

SNIFun = 
  fun(ServerName) ->
   %% get the URL from somewhere/config    
   {ok, ReqBin} = file:read_file("/tmp//ocsp3.req.b64"),
   Req = binary_to_list(ReqBin),
   Resp = httpc:request(
            get,
            {URL ++ Req,
             [{"connection", "close"}]},
            [{timeout, 15_000}],
            [{body_format, binary}]
           ),
   %% ...
  end.
```

```erlang
application:ensure_all_started(ssl).
application:ensure_all_started(inets).
rr(tls_handshake_1_3).
SNIFun =
  fun(ServerName) ->
    {ok, Resp} = file:read_file("/home/thales/dev/emqx/tls-scripts/ocsp-server.resp"),
    [ {certificate_status, #certificate_status{
                             status_type = 1,
                             response = Resp
                             }}
    ]
  end.
{ok, Lsock} = ssl:listen(
  1443,
  [
    {log_level, debug},
    {reuseaddr, true},
    {cacertfile, "/home/thales/dev/emqx/tls-scripts/merged-ca.pem"},
    {certfile, "/home/thales/dev/emqx/tls-scripts/server.pem"},
    {keyfile, "/home/thales/dev/emqx/tls-scripts/server.key"},
    %% {verify, verify_peer},
    %% {verify_fun, {VerifyFn, state}},
    {sni_fun, SNIFun},
    {ocsp_stapling, true},
    {ocsp_nonce, false}
  ]
).
Loop = fun Go () ->
  try
    {ok, TransSock} = ssl:transport_accept(Lsock),
    {ok, SslSock} = ssl:handshake(TransSock, 500_000),
    ok
  catch
    _:_ -> ok
  end,
  Go()
end.

Loop().
```

```sh
openssl s_client -connect localhost:1443 \
        -tls1_3 \
        -debug \
        -msg \
        -tlsextdebug \
        -state \
        -CAfile /home/thales/dev/emqx/tls-scripts/merged-ca.pem \
        -cert /home/thales/dev/emqx/tls-scripts/client.pem \
        -key /home/thales/dev/emqx/tls-scripts/client.key \
        -servername localhost \
        -status
```


##### References

- https://blog.voltone.net/post/21
- https://unmitigatedrisk.com/?p=42
- https://serverfault.com/questions/131983/openssl-how-to-setup-an-ocsp-server-for-checking-third-party-certificates